### PR TITLE
Improve attributes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -285,3 +285,25 @@ Power ups would just be something that when it collides with an enemy then it wo
 buttons though.
 
 * Enemy.x and Enemy.y should be attributes so that they could be grabbed by actions.
+
+* What cool shit could I do with actions now?
+   * I would be cool if instead of dying automatically and auto-triggering Game Over,
+     I could could trigger Game Over manually.
+     It would be cool if it was possible to give the player several lifes this way, like
+     decrementing a counter and then fully die when it eaches zero.
+     Actually, maybe I could replace `onDeathAction` with `waitUntilAttrIs` action so that I wait
+     until `hp` is 0.
+
+   * Points could be entirely managed by enemies themselves (in onHit callback or something).
+
+   * The intro screen could be a GameObject: It could render the Graphics and all.
+     It could have timers. It could listen to space button.
+     It could even be several images after each other.
+
+   * I could have boss phases with something like this:
+   ```
+   [
+      parallelRace(waitUntilAttrIs(flag, "phase2"), [some, actions]),
+      parallelRace(waitUntilAttrIs(flag, "phase3"), [some, actions]),
+   ]
+   ```

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -286,6 +286,8 @@ buttons though.
 
 * Enemy.x and Enemy.y should be attributes so that they could be grabbed by actions.
 
+* I will need `attrLessThan` and `AttrGreaterThan` actions.
+
 * What cool shit could I do with actions now?
    * I would be cool if instead of dying automatically and auto-triggering Game Over,
      I could could trigger Game Over manually.

--- a/docs/whatImCurrentlyDoing.md
+++ b/docs/whatImCurrentlyDoing.md
@@ -3,3 +3,4 @@ it easier to make levels, debug texts, debug buttons and tools etc.
 
 * I am adding ability to params in actions to be grabbed from an attribute.
   * I should also automatically add parentId to all childrens spawned.
+  * the attribute getter itself should be able to take an attribute getter!!!

--- a/docs/whatImCurrentlyDoing.md
+++ b/docs/whatImCurrentlyDoing.md
@@ -1,2 +1,5 @@
 * After that I should probably take small steps towards making stuff that makes
 it easier to make levels, debug texts, debug buttons and tools etc.
+
+* I am adding ability to params in actions to be grabbed from an attribute.
+  * I should also automatically add parentId to all childrens spawned.

--- a/src/App/services/Attributes/Attributes.ts
+++ b/src/App/services/Attributes/Attributes.ts
@@ -39,7 +39,7 @@ export class Attributes implements IAttributes {
       const value = this.attributes.gameObjects[gameObjectId]?.[attribute];
       if(value === undefined){
          const msg = `Attribute:  Attribute "${attribute}" does not exist.`;
-         console.error(msg);
+         console.warn(msg);
       }
       // guaranteed to exist since previous if case.
       return value!;
@@ -52,6 +52,7 @@ export class Attributes implements IAttributes {
          return;
       }
       // init if it did not exist.
+      // TODO: This only needs to be done once when the enmey is created maybe.
       this.attributes.gameObjects[gameObjectId] = {
          [attribute]: value
       };
@@ -59,6 +60,28 @@ export class Attributes implements IAttributes {
 
    public getAttribute = (params: TGameObjectIdAndAttrParams): TAttrValue => {
       return this.getAndAssertAttribute(params);
+   };
+
+   public getNumber = ({ gameObjectId, attribute }: TGameObjectIdAndAttrParams): number => {
+      const value = this.attributes.gameObjects[gameObjectId]?.[attribute];
+      if(typeof value !== "number"){
+         const msg = `Attributes.getNumber: "${attribute}" expected to be number but is ${value}.`;
+         console.error(msg);
+      }
+      // guaranteed to exist since previous if case.
+      return value as number; // TODO: Fix.
+   };
+   public getString = ({ gameObjectId, attribute }: TGameObjectIdAndAttrParams): string => {
+      const value = this.attributes.gameObjects[gameObjectId]?.[attribute];
+      if(typeof value !== "string"){
+         const msg = `Attributes.getString: "${attribute}" expected to be string but is ${value}.`;
+         console.error(msg);
+      }
+      // guaranteed to exist since previous if case.
+      return value as string; // TODO: Fix.
+   };
+   public getBool = ({ gameObjectId, attribute }: TGameObjectIdAndAttrParams): boolean => {
+      return !!this.attributes.gameObjects[gameObjectId]?.[attribute];
    };
 
    public incr = (params: TIncrDecrAttrParams) => {

--- a/src/App/services/Attributes/IAttributes.ts
+++ b/src/App/services/Attributes/IAttributes.ts
@@ -41,6 +41,9 @@ export type TIncrDecrAttrParams = { gameObjectId: string, attribute: string };
 export interface IAttributes extends IService, IDestroyable {
    setAttribute: ({ gameObjectId, attribute, value }: TSetAttrParams) => void;
    getAttribute: (params: TGameObjectIdAndAttrParams) => TAttrValue;
+   getNumber: (params: TGameObjectIdAndAttrParams) => number;
+   getString: (params: TGameObjectIdAndAttrParams) => string;
+   getBool: (params: TGameObjectIdAndAttrParams) => boolean;
    incr: (params: TIncrDecrAttrParams) => void;
    decr: (params: TIncrDecrAttrParams) => void;
 }

--- a/src/App/services/Attributes/IAttributes.ts
+++ b/src/App/services/Attributes/IAttributes.ts
@@ -1,11 +1,26 @@
 import type { IService } from "../IService";
 import type { IDestroyable } from "../../../utils/types/IDestroyable";
+import type { LiteralUnion } from "type-fest";
 
 /**
  * End-user should be able to set attributes, they will be like variables,
  * that is why they need to be able to be of different types.
  */
 export type TAttrValue = string | number | boolean;
+
+/**
+ * to aid with autocompletion for attriubte keys/names.
+ * TODO: Move this and similar up into gameTypes folder, because thats where
+ * types that are needed to created a game/stage/level should go.
+ */
+export type TAttrName = LiteralUnion<
+   "points" |
+   "pointsOnDeath" |
+   "parentId" |
+   "collisionType" |
+   "boundToWindow",
+   string
+>
 
 export type TAttributes = {
    gameObjects: Partial<{
@@ -14,6 +29,8 @@ export type TAttributes = {
          points: number;
          // how many points you get when this dies.
          pointsOnDeath: number;
+         // stores the id of the GameObject that is the parent, i.e. the one that created this child
+         parentId: string;
          // hp?: number;
          // maxHp?: number;
          /**

--- a/src/App/services/Enemies/Enemies.ts
+++ b/src/App/services/Enemies/Enemies.ts
@@ -66,13 +66,19 @@ export class Enemies implements IService {
    };
 
    public Spawn = (
-      { enemy, position, prependActions=[] }:
-      { enemy: string, position: TVector, prependActions?: TAction[] }
+      { enemy, position, prependActions=[], parentId }:
+      { enemy: string, position: TVector, prependActions?: TAction[], parentId?: string }
    ) => {
       // console.log(`Enemies.Spawn: enemy: ${enemy}`);
       // console.log(`Spawn ${enemy} at ${JSON.stringify(position)}`);
       const enemyJson = this.gameData.GetEnemy(enemy);
       // console.log(`Enemies.Spawn: enemyJson.name: ${enemyJson.name}`);
+
+      // action that sets the parentId attribute to hold what gameObject spawned this GameObject.
+      const parentIdAction = (parentId ?
+         [{ type: AT.setAttribute, attribute: "parentId", value: parentId } as const]:
+         []
+      );
 
       /**
        * prepend the actions that the parent sent. this allow parent some control over it's spawn.
@@ -88,6 +94,7 @@ export class Enemies implements IService {
             { type: AT.setAttribute, attribute: "pointsOnDeath", value: 0 },
             { type: AT.setAttribute, attribute: "collisionType", value: "enemy" },
             { type: AT.setAttribute, attribute: "boundToWindow", value: false },
+            ...parentIdAction,
             {
                type: AT.fork,
                actions: [

--- a/src/App/services/Enemies/Enemies.ts
+++ b/src/App/services/Enemies/Enemies.ts
@@ -12,6 +12,7 @@ import type { Settings } from "../Settings/Settings";
 import type { TAction } from "./actions/actionTypes";
 import type { IAttributes } from "../Attributes/IAttributes";
 
+import { ActionType as AT } from "./actions/actionTypes";
 import { Enemy } from "./Enemy";
 
 export class Enemies implements IService {
@@ -83,17 +84,17 @@ export class Enemies implements IService {
          ...enemyJson,
          actions: [
             // Set some default attributes. TODO: Should prolly do this in another way.
-            { type: "setAttribute", attribute: "points", value: 10 },
-            { type: "setAttribute", attribute: "pointsOnDeath", value: 0 },
-            { type: "setAttribute", attribute: "collisionType", value: "enemy" },
-            { type: "setAttribute", attribute: "boundToWindow", value: false },
+            { type: AT.setAttribute, attribute: "points", value: 10 },
+            { type: AT.setAttribute, attribute: "pointsOnDeath", value: 0 },
+            { type: AT.setAttribute, attribute: "collisionType", value: "enemy" },
+            { type: AT.setAttribute, attribute: "boundToWindow", value: false },
             {
                type: "fork",
                actions: [
                   // TODO: Comment
                   { type: "waitTilInsideScreen" },
                   { type: "waitTilOutsideScreen" },
-                  { type: "despawn" }
+                  { type: AT.despawn }
                ]
             },
             ...prependActions,

--- a/src/App/services/Enemies/Enemies.ts
+++ b/src/App/services/Enemies/Enemies.ts
@@ -89,11 +89,11 @@ export class Enemies implements IService {
             { type: AT.setAttribute, attribute: "collisionType", value: "enemy" },
             { type: AT.setAttribute, attribute: "boundToWindow", value: false },
             {
-               type: "fork",
+               type: AT.fork,
                actions: [
                   // TODO: Comment
-                  { type: "waitTilInsideScreen" },
-                  { type: "waitTilOutsideScreen" },
+                  { type: AT.waitTilInsideScreen },
+                  { type: AT.waitTilOutsideScreen },
                   { type: AT.despawn }
                ]
             },

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -170,70 +170,70 @@ export class Enemy {
     */
    private HandleAction = (action: TAction) => {
       switch(action.type /* TODO: as AT */) {
-         case "shootDirection":
+         case AT.shootDirection:
             this.ShootDirection({ dirX: action.x, dirY: action.y });
             break;
-         case "setSpeed":
+         case AT.setSpeed:
             this.speed = action.pixelsPerFrame;
             break;
-         case "setShotSpeed":
+         case AT.setShotSpeed:
             this.shotSpeed = action.pixelsPerFrame;
             break;
-         case "set_position":
+         case AT.set_position:
             this.SetPosition({ x: action.x, y: action.y });
             break;
-         case "shoot_toward_player":
+         case AT.shootTowardPlayer:
             this.ShootTowardPlayer();
             break;
-         case "shoot_beside_player":
+         case AT.shoot_beside_player:
             this.ShootBesidePlayer(action.degrees);
             break;
-         case "rotate_towards_player":
+         case AT.rotate_towards_player:
             this.RotateTowardsPlayer();
             break;
-         case "setMoveDirection":
+         case AT.setMoveDirection:
             this.setMoveDirection(action.degrees);
             break;
-         case "move_according_to_speed_and_direction":
+         case AT.move_according_to_speed_and_direction:
             this.moveAccordingToSpeedAndDirection();
             break;
-         case "spawn": {
+         case AT.spawn: {
             // console.log(`Enemy: spawning: ${action.enemy}`);
             const { enemy, x=0, y=0, actions } = action;
             this.spawn({ enemy, pos: { x, y }, actions });
             break;
          }
-         case "mirrorX": 
+         case AT.mirrorX: 
             this.mirrorX = action.value;
             break;
-         case "mirrorY": 
+         case AT.mirrorY: 
             this.mirrorY = action.value;
             break;
-         case "moveDelta":
+         case AT.moveDelta:
             this.moveDelta({ x: action.x, y: action.y });
             break;
-         case "setAttribute": { // this I believe could be move into EnemyActionExecutor??
+         case AT.setAttribute: { // this I believe could be move into EnemyActionExecutor??
             const { gameObjectId, attribute, value } = action;
             this.attrs.setAttribute({ gameObjectId: gameObjectId ?? this.id, attribute, value });
             break;
          }
-         case "despawn":
+         case AT.despawn:
             this.despawn();
             break;
-         case "die":
+         case AT.die:
             this.die();
             break;
-         case "incr": { // this I believe could be move into EnemyActionExecutor??
+         case AT.incr: { // this I believe could be move into EnemyActionExecutor??
             const { gameObjectId, attribute } = action;
             this.attrs.incr({ gameObjectId: gameObjectId ?? this.id, attribute});
             break;
          }
-         case "decr": { // this I believe could be move into EnemyActionExecutor??
+         case AT.decr: { // this I believe could be move into EnemyActionExecutor??
             const { gameObjectId, attribute } = action;
             this.attrs.decr({ gameObjectId: gameObjectId ?? this.id, attribute});
             break;
          }
-         case "finishLevel": // TODO: dispatch some new "finishLevel" event instead.
+         case AT.finishLevel: // TODO: dispatch some new "finishLevel" event instead.
             this.enemies.events.dispatchEvent({ type: "player_died" }); 
             break;
          default:

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -4,6 +4,7 @@ import type { IGraphics, TGraphicsActionWithoutHandle } from "../Graphics/IGraph
 import type { Enemies } from "./Enemies";
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "./actions/actionTypes";
 import { EnemyActionExecutor } from "./EnemyActionExecutor";
 import { Vector } from "../../../math/Vector";
 import { Angle } from "../../../math/Angle";
@@ -168,7 +169,7 @@ export class Enemy {
     * Actually one-lines are okey to inline here.
     */
    private HandleAction = (action: TAction) => {
-      switch(action.type) {
+      switch(action.type /* TODO: as AT */) {
          case "shootDirection":
             this.ShootDirection({ dirX: action.x, dirY: action.y });
             break;
@@ -258,15 +259,15 @@ export class Enemy {
          actions:  [{
             type: "fork",
             actions: [{
-               type: "repeat",
+               type: AT.repeat,
                times: 99999,
                actions: [
                   /**
                    * TODO: This could instead be made with a `setMoveDir`, `setMoveSpd`,
                    * and then in yaml file a `moveAccordingToDirAndSpeed` action.
                    */
-                  { type: "moveDelta", x: dirX * speedUpFactor, y: dirY * speedUpFactor },
-                  { type: "waitNextFrame" }
+                  { type: AT.moveDelta, x: dirX * speedUpFactor, y: dirY * speedUpFactor },
+                  { type: AT.waitNextFrame }
                ]
             }]
          }]

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -257,7 +257,7 @@ export class Enemy {
          enemy: "shot",
          pos: { x: 0, y: 0 },
          actions:  [{
-            type: "fork",
+            type: AT.fork,
             actions: [{
                type: AT.repeat,
                times: 99999,

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -212,11 +212,6 @@ export class Enemy {
          case AT.moveDelta:
             this.moveDelta({ x: action.x, y: action.y });
             break;
-         case AT.setAttribute: { // this I believe could be move into EnemyActionExecutor??
-            const { gameObjectId, attribute, value } = action;
-            this.attrs.setAttribute({ gameObjectId: gameObjectId ?? this.id, attribute, value });
-            break;
-         }
          case AT.despawn:
             this.despawn();
             break;

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -330,7 +330,12 @@ export class Enemy {
    ) => {
       // Make a relative position into an absolute one.
       const absolute = { x: pos.x + this.X, y: pos.y + this.Y };
-      this.enemies.Spawn({ enemy, position: absolute, prependActions: actions });
+      this.enemies.Spawn({
+         enemy,
+         position: absolute,
+         prependActions: actions,
+         parentId: this.id, // send in that THIS enemy is the parent of the child being spawned.
+      });
    };
 
    public getPosition = (): TVector => {

--- a/src/App/services/Enemies/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/EnemyActionExecutor.ts
@@ -7,6 +7,7 @@ import type { IInput } from "../Input/IInput";
 import type { GamePad } from "../GamePad/GamePad";
 import type { Enemy } from "./Enemy";
 
+import { ActionType as AT } from "./actions/actionTypes";
 import { Vector } from "../../../math/Vector";
 import { Angle } from "../../../math/Angle";
 import { GeneratorUtils } from "../../../utils/GeneratorUtils";
@@ -137,7 +138,7 @@ export class EnemyActionExecutor {
                if (up) { y -= speed; }
                if (down) { y += speed; }
                if(x !== 0 || y !== 0) {
-                  this.actionHandler({ type: "moveDelta", x, y });
+                  this.actionHandler({ type: AT.moveDelta, x, y });
                }
                break;
             }
@@ -265,7 +266,7 @@ export class EnemyActionExecutor {
                 * allow passedFrames to go all the way up to 4.
                 */
                for(let passedFrames=1; passedFrames<=currAction.frames; passedFrames++) {
-                  this.actionHandler({ type: "moveDelta", x: stepX, y: stepY });
+                  this.actionHandler({ type: AT.moveDelta, x: stepX, y: stepY });
                   yield;
                }
                break;
@@ -279,7 +280,7 @@ export class EnemyActionExecutor {
                const stepX = moveX / currAction.frames;
                const stepY = moveY / currAction.frames;
                for(let passedFrames=1; passedFrames<=currAction.frames; passedFrames++) {
-                  this.actionHandler({ type: "moveDelta", x: stepX, y: stepY });
+                  this.actionHandler({ type: AT.moveDelta, x: stepX, y: stepY });
                   yield;
                }
                break;
@@ -330,7 +331,7 @@ const rotateAroundPoint = function*(
       const currRotated = pointToPosVector.rotateClockwise(Angle.fromDegrees(currDegrees));
 
       const delta = Vector.fromTo(prevRotated, currRotated);
-      actionHandler({ type: "moveDelta", x: delta.x, y: delta.y });
+      actionHandler({ type: AT.moveDelta, x: delta.x, y: delta.y });
       yield;
    }
 };

--- a/src/App/services/Enemies/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/EnemyActionExecutor.ts
@@ -1,5 +1,5 @@
 import type {
-   TAction, TNumber, TRotateAroundAbsolutePoint, TRotateAroundRelativePoint
+   TAction, TNumber, TRotateAroundAbsolutePoint, TRotateAroundRelativePoint, TString
 } from "./actions/actionTypes";
 import type { Vector as TVector } from "../../../math/bezier";
 import type { IAttributes, TAttrValue } from "../Attributes/IAttributes";
@@ -17,8 +17,7 @@ type TActionHandler = (action: TAction) => void;
 
 type TEnemyActionExecutorArgs = {
    /**
-   * The actions to execute.
-   * Executes them in sequence.
+   * The actions to execute. Executes them in sequence.
    * You can execute things in parallel with special compound actions like parallelRace.
    */
    actions: TAction[];
@@ -111,6 +110,16 @@ export class EnemyActionExecutor {
          attribute: param.attr
       });
    };
+   /** Get/extract a hardcoded string or an attribute */
+   private getString = (param: TString): string => {
+      if (typeof param === "string") {
+         return param;
+      }
+      return this.attrs.getString({
+         gameObjectId: param.gameObjectId ?? this.enemy.id,
+         attribute: param.attr
+      });
+   };
 
    private *makeGenerator(
       actions: TAction[] = []
@@ -168,8 +177,13 @@ export class EnemyActionExecutor {
             }
 
             case AT.waitUntilAttrIs: {
-               const { gameObjectId, attr: attribute, is } = currAction;
-               while(this.getAttribute({ gameObjectId, attribute }) !== is) { yield; }
+               const { gameObjectId, attr, is } = currAction;
+               while(this.getAttribute({
+                  gameObjectId: gameObjectId ? this.getString(gameObjectId) : undefined,
+                  attribute: attr
+               }) !== is) {
+                  yield;
+               }
                break;
             }
 
@@ -227,8 +241,8 @@ export class EnemyActionExecutor {
             }
 
             case AT.wait: {
-               const frames = this.getNumber(currAction.frames);
-               for(let i=0; i<frames; i++) { yield; }
+               // const frames = this.getNumber(currAction.frames);
+               for(let i=0; i<this.getNumber(currAction.frames); i++) { yield; }
                break;
             }
 

--- a/src/App/services/Enemies/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/EnemyActionExecutor.ts
@@ -113,7 +113,7 @@ export class EnemyActionExecutor {
          // }
          // console.log(currAction.type);
          switch(currAction.type) {
-            case "moveAccordingToInput": {
+            case AT.moveAccordingToInput: {
                const input = this.input;
                const gamepad = this.gamepad;
 
@@ -143,25 +143,25 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "waitInputShoot": {
+            case AT.waitInputShoot: {
                const shootPressed = () => this.shootPressed() && !this.laserPressed();
                while(!shootPressed()) { yield; }
                break;
             }
 
-            case "waitInputLaser": {
+            case AT.waitInputLaser: {
                const laserPressed = () => this.laserPressed();
                while(!laserPressed()) { yield; }
                break;
             }
 
-            case "waitUntilAttrIs": {
+            case AT.waitUntilAttrIs: {
                const { gameObjectId, attr: attribute, is } = currAction;
                while(this.getAttribute({ gameObjectId, attribute }) !== is) { yield; }
                break;
             }
 
-            case "fork": {
+            case AT.fork: {
                // Create a new generator for the fork to allow it to execute parallely.
                const generator = this.makeGenerator(currAction.actions);
                this.generators.push(generator);
@@ -170,24 +170,24 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "do": { // flatten essentially.
+            case AT.do: { // flatten essentially.
                yield* this.makeGenerator(currAction.acns);
                break;
             }
 
-            case "parallelRace": {
+            case AT.parallelRace: {
                const generators = currAction.actionsLists.map(acns => this.makeGenerator(acns));
                yield* GeneratorUtils.parallelRace(generators);
                break;
             }
 
-            case "parallelAll": {
+            case AT.parallelAll: {
                const generators = currAction.actionsLists.map(acns => this.makeGenerator(acns));
                yield* GeneratorUtils.parallelAll(generators);
                break;
             }
 
-            case "repeat": {
+            case AT.repeat: {
                yield*  GeneratorUtils.Repeat({
                   makeGenerator: () => this.makeGenerator(currAction.actions),
                   times: currAction.times
@@ -195,19 +195,19 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "attrIs": {
+            case AT.attrIs: {
                const { attrName: attribute, gameObjectId, is, yes, no } = currAction;
                const attrValue = this.getAttribute({ gameObjectId, attribute });
                yield* this.makeGenerator(attrValue === is ? yes : no);
                break;
             }
 
-            case "waitNextFrame": {
+            case AT.waitNextFrame: {
                yield;
                break;
             }
 
-            case "wait": {
+            case AT.wait: {
                // if (this.enemy.id.includes("spin") || this.enemy.id.includes("stage")) {
                //    console.log(`${this.enemy.id} started waiting ${currAction.frames} frames`);
                // }
@@ -223,7 +223,7 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "waitTilInsideScreen": {
+            case AT.waitTilInsideScreen: {
                const margin = 0; // was 20
                const left = -margin;
                const right = resolutionWidth + margin;
@@ -239,7 +239,7 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "waitTilOutsideScreen": {
+            case AT.waitTilOutsideScreen: {
                const left = -30;
                const right = resolutionWidth + 30;
                const top = -30;
@@ -254,7 +254,7 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "move": {
+            case AT.move: {
                const moveX = currAction.x ?? 0;
                const moveY = currAction.y ?? 0;
                const stepX = moveX / currAction.frames;
@@ -272,7 +272,7 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "moveToAbsolute": {
+            case AT.moveToAbsolute: {
                const startPos = this.enemy.getPosition();
                const { moveTo } = currAction;
                const moveX = moveTo.x !== undefined ? moveTo.x - startPos.x : 0;
@@ -286,7 +286,7 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "rotate_around_relative_point": {
+            case AT.rotate_around_relative_point: {
                const pointX = currAction.point.x ?? 0;
                const pointY = currAction.point.y ?? 0;
                const pointToPosVector = new Vector(-pointX, -pointY);
@@ -294,7 +294,7 @@ export class EnemyActionExecutor {
                break;
             }
 
-            case "rotate_around_absolute_point": {
+            case AT.rotate_around_absolute_point: {
                const startPos = this.enemy.getPosition();
                const pointX = currAction.point.x ?? startPos.x;
                const pointY = currAction.point.y ?? startPos.y;

--- a/src/App/services/Enemies/EnemyGfx.ts
+++ b/src/App/services/Enemies/EnemyGfx.ts
@@ -44,14 +44,14 @@ export class EnemyGfx {
 
    public dispatch = (action: TGraphicsActionWithoutHandle) => {
       switch(action.type) {
-         case "gfxSetColor":
-         case "gfxSetDiameter":
-         case "gfxSetPosition":
-         case "gfxSetRotation":
-         case "gfxSetShape":
-         case "gfxSetScale":
-         case "gfxScrollBg":
-         case "gfxFillScreen":
+         case AT.gfxSetColor:
+         case AT.gfxSetDiameter:
+         case AT.gfxSetPosition:
+         case AT.gfxSetRotation:
+         case AT.gfxSetShape:
+         case AT.gfxSetScale:
+         case AT.gfxScrollBg:
+         case AT.gfxFillScreen:
             this.graphics.Dispatch({ ...action, handle: this.gfxHandle });
             break;
          default:

--- a/src/App/services/Enemies/EnemyGfx.ts
+++ b/src/App/services/Enemies/EnemyGfx.ts
@@ -3,8 +3,8 @@ import type {
    IGraphics, TGraphicsActionWithoutHandle , TResponse_AskForElement
 } from "../Graphics/IGraphics";
 
+import { ActionType as AT } from "./actions/actionTypes";
 import { BrowserDriver } from "../../../drivers/BrowserDriver";
-
 
 type TConstructor = {
    graphics: IGraphics; // Graphics service;
@@ -23,23 +23,23 @@ export class EnemyGfx {
       this.graphics = graphics;
 
       this.gfxHandle =
-         (this.graphics.Dispatch({ type:"gfxAskForElement" }) as TResponse_AskForElement).handle;
-      this.graphics.Dispatch({ type:"gfxSetPosition", handle: this.gfxHandle, x, y });
-      this.graphics.Dispatch({ type:"gfxSetDiameter", handle: this.gfxHandle, diameter });
-      this.graphics.Dispatch({ type:"gfxSetColor", handle: this.gfxHandle, color: "red" });
-      this.graphics.Dispatch({ type:"gfxSetShape", handle: this.gfxHandle, shape: "diamondShield"});
+         (this.graphics.Dispatch({ type:AT.gfxAskForElement }) as TResponse_AskForElement).handle;
+      this.graphics.Dispatch({ type:AT.gfxSetPosition, handle: this.gfxHandle, x, y });
+      this.graphics.Dispatch({ type:AT.gfxSetDiameter, handle: this.gfxHandle, diameter });
+      this.graphics.Dispatch({ type:AT.gfxSetColor, handle: this.gfxHandle, color: "red" });
+      this.graphics.Dispatch({ type:AT.gfxSetShape, handle: this.gfxHandle, shape:"diamondShield"});
    }
 
    public setPosition = ({ x, y }: TVector) => {
-      this.graphics.Dispatch({ type:"gfxSetPosition", handle: this.gfxHandle, x, y });
+      this.graphics.Dispatch({ type:AT.gfxSetPosition, handle: this.gfxHandle, x, y });
    };
 
    public release = () => {
-      this.graphics.Dispatch({ type: "gfxRelease", handle: this.gfxHandle });
+      this.graphics.Dispatch({ type: AT.gfxRelease, handle: this.gfxHandle });
    };
 
    public setRotation = ({ degrees }: { degrees: number }) => {
-      this.graphics.Dispatch({ type: "gfxSetRotation", handle: this.gfxHandle, degrees: degrees });
+      this.graphics.Dispatch({ type: AT.gfxSetRotation, handle: this.gfxHandle, degrees: degrees });
    };
 
    public dispatch = (action: TGraphicsActionWithoutHandle) => {

--- a/src/App/services/Enemies/__tests__/move.test.ts
+++ b/src/App/services/Enemies/__tests__/move.test.ts
@@ -4,6 +4,7 @@ import type { TAction, TSetPosition } from "../actions/actionTypes";
 
 import { describe, it, expect } from "vitest";
 
+import { ActionType as AT } from "../actions/actionTypes";
 import { EnemyActionExecutor } from "../EnemyActionExecutor";
 
 const input: any = undefined;
@@ -27,7 +28,7 @@ describe("move", () => {
          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
          gamepad,
          actions: [{
-            type: "move",
+            type: AT.move,
             x: 1,
             y: 0,
             frames: 0
@@ -50,7 +51,7 @@ describe("move", () => {
          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
          gamepad,
          actions: [{
-            type: "move",
+            type: AT.move,
             x: 1,
             y: 0,
             frames: 1
@@ -79,7 +80,7 @@ describe("move", () => {
          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
          gamepad,
          actions: [{
-            type: "move",
+            type: AT.move,
             x: 2,
             y: 0,
             frames: 2

--- a/src/App/services/Enemies/__tests__/parallell_race.test.ts
+++ b/src/App/services/Enemies/__tests__/parallell_race.test.ts
@@ -4,6 +4,7 @@ import type { TAction } from "../actions/actionTypes";
 
 import { describe, it, expect } from "vitest";
 
+import { ActionType as AT } from "../actions/actionTypes";
 import { EnemyActionExecutor } from "../EnemyActionExecutor";
 
 const input: any = undefined;
@@ -26,7 +27,7 @@ describe("parallelRace", () => {
          input,
          gamepad,
          actions: [{
-            type: "parallelRace",
+            type: AT.parallelRace,
             actionsLists: [[]]
          }]
       }).generators[0];
@@ -45,11 +46,11 @@ describe("parallelRace", () => {
          input,
          gamepad,
          actions: [{
-            type: "parallelRace",
+            type: AT.parallelRace,
             actionsLists: [
                [],
                [
-                  { type: "setSpeed", pixelsPerFrame: 1 }
+                  { type: AT.setSpeed, pixelsPerFrame: 1 }
                ]
             ]
          }]
@@ -69,12 +70,12 @@ describe("parallelRace", () => {
          input,
          gamepad,
          actions: [{
-            type: "parallelRace",
+            type: AT.parallelRace,
             actionsLists: [[
-               { type: "setSpeed", pixelsPerFrame: 1 }
+               { type: AT.setSpeed, pixelsPerFrame: 1 }
             ], [
-               { type: "waitNextFrame" },
-               { type: "setSpeed", pixelsPerFrame: 1 }
+               { type: AT.waitNextFrame },
+               { type: AT.setSpeed, pixelsPerFrame: 1 }
             ]]
          }]
       }).generators[0];
@@ -93,14 +94,14 @@ describe("parallelRace", () => {
          input,
          gamepad,
          actions: [{
-            type: "parallelRace",
+            type: AT.parallelRace,
             actionsLists: [[
-               { type: "waitNextFrame" },
-               { type: "setSpeed", pixelsPerFrame: 1 }
+               { type: AT.waitNextFrame },
+               { type: AT.setSpeed, pixelsPerFrame: 1 }
             ], [
-               { type: "waitNextFrame" },
-               { type: "waitNextFrame" },
-               { type: "setSpeed", pixelsPerFrame: 1 }
+               { type: AT.waitNextFrame },
+               { type: AT.waitNextFrame },
+               { type: AT.setSpeed, pixelsPerFrame: 1 }
             ]]
          }]
       }).generators[0];

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -2,79 +2,127 @@ import type { Vector } from "../../../../math/bezier";
 import type { TGraphicsActionWithoutHandle } from "../../Graphics/IGraphics";
 import type { TAttrValue } from "../../Attributes/IAttributes";
 
-export type TWait =                Readonly<{ type: "wait", frames: number }>;
-export type TWaitNextFrame =       Readonly<{ type: "waitNextFrame" }>;
-export type TWaitUtilFrameNr =     Readonly<{ type: "wait_util_frame_nr", frameNr: number}>;
-export type TRepeat =              Readonly<{ type: "repeat", times: number, actions: TAction[] }>;
-export type TShootDirection =      Readonly<{ type: "shootDirection", x: number, y: number }>;
-export type TShootTowardPlayer =   Readonly<{ type: "shoot_toward_player" }>;
-export type TShootBesidePlayer =   Readonly<{ type: "shoot_beside_player", degrees: number }>;
-export type TSetShotSpeed =        Readonly<{ type: "setShotSpeed", pixelsPerFrame: number }>;
+/**
+ * Action type enum.
+ * It's often the best to have consts instead of strings. "Find all references" works better in IDE.
+ * Enums are cool in one way: According to TS you are not allowed to assign a string to an enum,
+ * so it forces you to use the enum everywhere which is great!
+ */
+export enum ActionType {
+   wait = "wait",
+   waitNextFrame = "waitNextFrame",
+   waitUntilFrameNr = "wait_util_frame_nr",
+   repeat = "repeat",
+   shootDirection = "shootDirection",
+   shootTowardPlayer = "shoot_toward_player",
+   shoot_beside_player = "shoot_beside_player",
+   setShotSpeed = "setShotSpeed",
+   move = "move",
+   moveDelta = "moveDelta",
+   moveToAbsolute = "moveToAbsolute",
+   set_position = "set_position",
+   setSpeed = "setSpeed",
+   rotate_around_absolute_point = "rotate_around_absolute_point",
+   rotate_around_relative_point = "rotate_around_relative_point",
+   parallelRace = "parallelRace",
+   parallelAll = "parallelAll",
+   rotate_towards_player = "rotate_towards_player",
+   move_according_to_speed_and_direction = "move_according_to_speed_and_direction",
+   spawn = "spawn",
+   attrIs = "attrIs",
+   incr = "incr",
+   decr = "decr",
+   mirrorX = "mirrorX",
+   mirrorY = "mirrorY",
+   do = "do",
+   die = "die",
+   despawn = "despawn",
+   setAttribute = "setAttribute",
+}
+
+/** Action types */
+export type TWait =                Readonly<{ type: ActionType.wait, frames: number }>;
+export type TWaitNextFrame =       Readonly<{ type: ActionType.waitNextFrame }>;
+export type TWaitUtilFrameNr =     Readonly<{ type: ActionType.waitUntilFrameNr, frameNr: number}>;
+export type TRepeat =              Readonly<{ type: ActionType.repeat,
+                                                times: number, actions: TAction[] }>;
+export type TShootDirection =      Readonly<{ type: ActionType.shootDirection,
+                                                x: number, y: number }>;
+export type TShootTowardPlayer =   Readonly<{ type: ActionType.shootTowardPlayer }>;
+export type TShootBesidePlayer =   Readonly<{ type: ActionType.shoot_beside_player,
+                                                degrees: number }>;
+export type TSetShotSpeed =        Readonly<{ type: ActionType.setShotSpeed,
+                                                pixelsPerFrame: number }>;
 // Moves relative to current position.
-export type TMove =                Readonly<{ type: "move", frames: number } & Partial<Vector>>;
+export type TMove =                Readonly<{ type: ActionType.move,
+                                                frames: number } & Partial<Vector>>;
 // A very atomic action.
-export type TMoveDelta =           Readonly<{ type: "moveDelta", x?: number, y?: number }>
+export type TMoveDelta =           Readonly<{ type: ActionType.moveDelta, x?: number, y?: number }>
 // Move to an absolute postion on screen.
-export type TMoveToAbsolute =      Readonly<{ type: "moveToAbsolute",
-moveTo: Partial<Vector>, frames: number }>;
-export type TSetPosition =         Readonly<{ type: "set_position", x: number, y: number }>;
-export type TSetSpeed =            Readonly<{ type: "setSpeed", pixelsPerFrame: number }>;
+export type TMoveToAbsolute =      Readonly<{ type: ActionType.moveToAbsolute,
+                                                moveTo: Partial<Vector>, frames: number }>;
+export type TSetPosition =         Readonly<{ type: ActionType.set_position,
+                                                x: number, y: number }>;
+export type TSetSpeed =            Readonly<{ type: ActionType.setSpeed, pixelsPerFrame: number }>;
 export type TRotateAroundAbsolutePoint = Readonly<{
-   type: "rotate_around_absolute_point", point:Partial<Vector>, degrees:number, frames:number
+   type:ActionType.rotate_around_absolute_point, point:Partial<Vector>, degrees:number,frames:number
 }>;
 export type TRotateAroundRelativePoint = Readonly<{
-   type: "rotate_around_relative_point", point:Partial<Vector>, degrees:number, frames:number
+   type:ActionType.rotate_around_relative_point, point:Partial<Vector>, degrees:number,frames:number
 }>
 /**
  * Like Promise.race.
  * Executes TAction lists in parallel, stops when any one of them has finished.
  */
-export type TparallelRace       = Readonly<{ type: "parallelRace", actionsLists: TAction[][] }>;
-export type TparallelAll        = Readonly<{ type: "parallelAll", actionsLists: TAction[][] }>;
-export type TRotateTowardsPlayer = Readonly<{ type: "rotate_towards_player" }>;
-export type TMoveAccordingToSpeedAndDirection = { type: "move_according_to_speed_and_direction" };
+export type TparallelRace       = Readonly<{ type: ActionType.parallelRace,
+                                                actionsLists: TAction[][] }>;
+export type TparallelAll        = Readonly<{ type: ActionType.parallelAll,
+                                                actionsLists: TAction[][] }>;
+export type TRotateTowardsPlayer = Readonly<{ type: ActionType.rotate_towards_player }>;
+export type TMoveAccordingToSpeedAndDirection =
+                                       { type: ActionType.move_according_to_speed_and_direction };
 // Spawns an enemy. actions are prepended to the actions of the particular enemy.
 export type TSpawn = {
-   type: "spawn", enemy: string, x?: number, y?: number, actions?: TAction[]
+   type: ActionType.spawn, enemy: string, x?: number, y?: number, actions?: TAction[]
 };
 // Simple if-equals case. Executes yes if true. Executs no when false.
 export type TAttrIs = {
-   type: "attrIs", gameObjectId?: string, attrName: string,
+   type: ActionType.attrIs, gameObjectId?: string, attrName: string,
    is: TAttrValue, yes?: TAction[], no?: TAction[]
 };
 // Increments an attribute. Obviously will blow up if trying to increment a non-number.
 export type TIncrement =
-{ type: "incr", gameObjectId?: string, attribute: string };
+{ type: ActionType.incr, gameObjectId?: string, attribute: string };
 // Decrements an attribute. Obviously will blow up if trying to increment a non-number.
 export type TDecrement =
-{ type: "decr", gameObjectId?: string, attribute: string };
+{ type: ActionType.decr, gameObjectId?: string, attribute: string };
 
 /**
  * Mirroring mirrors an axis.
  * If you have an enemy that moves like another enemy, except
  * that every x movement is inverted then try mirrorX.
  */
-export type TMirrorX = { type: "mirrorX", value: boolean };
-export type TMirrorY = { type: "mirrorY", value: boolean };
+export type TMirrorX = { type: ActionType.mirrorX, value: boolean };
+export type TMirrorY = { type: ActionType.mirrorY, value: boolean };
 /**
  * The only purpose for this is to "flatten" arrays in YAML.
  * The action simple executes the actions sent to it. As simple as that.
  */
-export type TDo = { type: "do", acns: TAction[] };
+export type TDo = { type: ActionType.do, acns: TAction[] };
 // Well, the enemy dies.
-export type TDie = { type: "die" };
+export type TDie = { type: ActionType.die };
 /**
  * Enemy despawns. Like "die" except onDeathAction is NOT triggered.
  * An example of when this should be used is when an enemy despawns outside of the screen,
  * you probably don't want to trigger an onDeath with explodes the enemy into bullets.
  */
-export type TDespawn = { type: "despawn" };
+export type TDespawn = { type: ActionType.despawn };
 /**
  * Attributes can be either some predefined thing by me such as hp, points,
  * or it could be  end-user specified variable with any type.
  */
 export type TSetAttribute =
-   { type: "setAttribute", gameObjectId?: string, attribute: string, value: TAttrValue };
+   { type: ActionType.setAttribute, gameObjectId?: string, attribute: string, value: TAttrValue };
 // Waits until Enemy is outside the screen/game window
 export type TWaitTilOutsideScreen = { type: "waitTilOutsideScreen" };
 // Waits until Enemy is inside the screen/game window

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -10,7 +10,7 @@ import type { TAttrValue } from "../../Attributes/IAttributes";
  */
 export enum ActionType {
    wait = "wait",
-   waitNextFrame = "waitNextFrame",
+   waitNextFrame = "waitNextFrame", // TODO: Remove use "wait" instead.
    waitUntilFrameNr = "wait_util_frame_nr",
    repeat = "repeat",
    shootDirection = "shootDirection",
@@ -51,16 +51,20 @@ export enum ActionType {
    /**
     * GFX
     */
-   gfxAskForElement = "gfxAskForElement",
    gfxSetPosition = "gfxSetPosition",
    gfxSetDiameter = "gfxSetDiameter",
-   gfxRelease = "gfxRelease",
    gfxSetColor = "gfxSetColor",
    gfxSetShape = "gfxSetShape",
    gfxSetRotation = "gfxSetRotation",
    gfxSetScale = "gfxSetScale",
    gfxScrollBg = "gfxScrollBg",
    gfxFillScreen = "gfxFillScreen",
+
+   /**
+    * GFX that is only used internally by the engine.
+    */
+   gfxAskForElement = "gfxAskForElement",
+   gfxRelease = "gfxRelease",
 }
 
 /** Action types */

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -38,6 +38,20 @@ export enum ActionType {
    die = "die",
    despawn = "despawn",
    setAttribute = "setAttribute",
+   waitTilOutsideScreen = "waitTilOutsideScreen",
+   waitTilInsideScreen = "waitTilInsideScreen",
+   fork = "fork",
+   setMoveDirection = "setMoveDirection",
+   waitUntilAttrIs = "waitUntilAttrIs",
+   moveAccordingToInput = "moveAccordingToInput",
+   waitInputShoot = "waitInputShoot",
+   waitInputLaser = "waitInputLaser",
+   finishLevel = "finishLevel",
+
+   /**
+    * GFX
+    */
+   
 }
 
 /** Action types */
@@ -124,9 +138,9 @@ export type TDespawn = { type: ActionType.despawn };
 export type TSetAttribute =
    { type: ActionType.setAttribute, gameObjectId?: string, attribute: string, value: TAttrValue };
 // Waits until Enemy is outside the screen/game window
-export type TWaitTilOutsideScreen = { type: "waitTilOutsideScreen" };
+export type TWaitTilOutsideScreen = { type: ActionType.waitTilOutsideScreen };
 // Waits until Enemy is inside the screen/game window
-export type TWaitTilInsideScreen = { type: "waitTilInsideScreen" };
+export type TWaitTilInsideScreen = { type: ActionType.waitTilInsideScreen };
 /**
  * Fork is like fork in C essentially. The actions in fork executes separately
  * (in a separate generator) i.e. these actions won't delay other actions.
@@ -135,27 +149,27 @@ export type TWaitTilInsideScreen = { type: "waitTilInsideScreen" };
  * a new enemy and you want those actions to not delay the enemy's own actions, but rather
  * execute in parallel to them).
  */
-export type TFork = { type: "fork", actions: TAction[] };
+export type TFork = { type: ActionType.fork, actions: TAction[] };
 /**
  * Set only the move direction. Only specific some move actions care about the direction which 
  * gotta be called to move in the direction set with this action.
  */
-export type TMoveDirection = Readonly<{ type: "setMoveDirection", degrees: number }>;
+export type TMoveDirection = Readonly<{ type: ActionType.setMoveDirection, degrees: number }>;
 // Yields until the attribute has the value set in is.
 export type TWaitUntilAttrIs = Readonly<{
-   type: "waitUntilAttrIs", gameObjectId?: string, attr: string, is: TAttrValue
+   type: ActionType.waitUntilAttrIs, gameObjectId?: string, attr: string, is: TAttrValue
 }>;
 
 /**
  * This action is a way to react to input/gamepad/controls, mainly made in order
  * to allow the Player to be an Enemy (i.e. GameObject)
  */
-export type TMoveAccordingToInput = Readonly<{ type: "moveAccordingToInput" }>;
-export type TWaitInputShoot = Readonly<{ type: "waitInputShoot" }>;
-export type TWaitInputLaser = Readonly<{ type: "waitInputLaser" }>;
+export type TMoveAccordingToInput = Readonly<{ type: ActionType.moveAccordingToInput }>;
+export type TWaitInputShoot = Readonly<{ type: ActionType.waitInputShoot }>;
+export type TWaitInputLaser = Readonly<{ type: ActionType.waitInputLaser }>;
 
 // Signals that the level has been finished, so trigger this when end boss dies or something similar
-export type TFinishLevel = Readonly<{ type: "finishLevel" }>;
+export type TFinishLevel = Readonly<{ type: ActionType.finishLevel }>;
 
 export type TAction = Readonly<
    /**

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -29,25 +29,30 @@ export enum ActionType {
    rotate_towards_player = "rotate_towards_player",
    move_according_to_speed_and_direction = "move_according_to_speed_and_direction",
    spawn = "spawn",
-   attrIs = "attrIs",
-   incr = "incr",
-   decr = "decr",
    mirrorX = "mirrorX",
    mirrorY = "mirrorY",
    do = "do",
    die = "die",
    despawn = "despawn",
-   setAttribute = "setAttribute",
    waitTilOutsideScreen = "waitTilOutsideScreen",
    waitTilInsideScreen = "waitTilInsideScreen",
    fork = "fork",
    setMoveDirection = "setMoveDirection",
-   waitUntilAttrIs = "waitUntilAttrIs",
    moveAccordingToInput = "moveAccordingToInput",
    waitInputShoot = "waitInputShoot",
    waitInputLaser = "waitInputLaser",
    finishLevel = "finishLevel",
-
+   
+   /**
+    * Attributes
+    */
+   setAttribute = "setAttribute",
+   attrIs = "attrIs",
+   incr = "incr",
+   decr = "decr",
+   waitUntilAttrIs = "waitUntilAttrIs",
+   
+   
    /**
     * GFX
     */

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -1,6 +1,6 @@
 import type { Vector } from "../../../../math/bezier";
 import type { TGraphicsActionWithoutHandle } from "../../Graphics/IGraphics";
-import type { TAttrValue } from "../../Attributes/IAttributes";
+import type { TAttrName, TAttrValue } from "../../Attributes/IAttributes";
 
 /**
  * Action type enum.
@@ -76,7 +76,7 @@ export enum ActionType {
  * Used to get the value of an attribute an inject that into an action that would otherwise take
  * a integer, float, bool, or string. This is to make stuff more dynamic and flexible.
  */
-type TAttrGetter = Readonly<{ gameObjectId?: string, attr: string }>;
+type TAttrGetter = Readonly<{ gameObjectId?: string, attr: TAttrName }>;
 
 /**
  * Types for primitive values.
@@ -134,15 +134,15 @@ export type TSpawn = {
 };
 // Simple if-equals case. Executes yes if true. Executs no when false.
 export type TAttrIs = {
-   type: ActionType.attrIs, gameObjectId?: string, attrName: string,
+   type: ActionType.attrIs, gameObjectId?: string, attrName: TAttrName,
    is: TAttrValue, yes?: TAction[], no?: TAction[]
 };
 // Increments an attribute. Obviously will blow up if trying to increment a non-number.
 export type TIncrement =
-{ type: ActionType.incr, gameObjectId?: string, attribute: string };
+{ type: ActionType.incr, gameObjectId?: string, attribute: TAttrName };
 // Decrements an attribute. Obviously will blow up if trying to increment a non-number.
 export type TDecrement =
-{ type: ActionType.decr, gameObjectId?: string, attribute: string };
+{ type: ActionType.decr, gameObjectId?: string, attribute: TAttrName };
 
 /**
  * Mirroring mirrors an axis.
@@ -169,7 +169,7 @@ export type TDespawn = { type: ActionType.despawn };
  * or it could be  end-user specified variable with any type.
  */
 export type TSetAttribute =
-   { type: ActionType.setAttribute, gameObjectId?: string, attribute: string, value: TAttrValue };
+   { type: ActionType.setAttribute, gameObjectId?: string, attribute: TAttrName, value: TAttrValue};
 // Waits until Enemy is outside the screen/game window
 export type TWaitTilOutsideScreen = { type: ActionType.waitTilOutsideScreen };
 // Waits until Enemy is inside the screen/game window
@@ -190,7 +190,7 @@ export type TFork = { type: ActionType.fork, actions: TAction[] };
 export type TMoveDirection = Readonly<{ type: ActionType.setMoveDirection, degrees: number }>;
 // Yields until the attribute has the value set in is.
 export type TWaitUntilAttrIs = Readonly<{
-   type: ActionType.waitUntilAttrIs, gameObjectId?: string, attr: string, is: TAttrValue
+   type: ActionType.waitUntilAttrIs, gameObjectId?: TString, attr: TAttrName, is: TAttrValue
 }>;
 
 /**

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -51,7 +51,16 @@ export enum ActionType {
    /**
     * GFX
     */
-   
+   gfxAskForElement = "gfxAskForElement",
+   gfxSetPosition = "gfxSetPosition",
+   gfxSetDiameter = "gfxSetDiameter",
+   gfxRelease = "gfxRelease",
+   gfxSetColor = "gfxSetColor",
+   gfxSetShape = "gfxSetShape",
+   gfxSetRotation = "gfxSetRotation",
+   gfxSetScale = "gfxSetScale",
+   gfxScrollBg = "gfxScrollBg",
+   gfxFillScreen = "gfxFillScreen",
 }
 
 /** Action types */

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -10,7 +10,7 @@ import type { TAttrValue } from "../../Attributes/IAttributes";
  */
 export enum ActionType {
    wait = "wait",
-   waitNextFrame = "waitNextFrame", // TODO: Remove use "wait" instead.
+   waitNextFrame = "waitNextFrame",
    waitUntilFrameNr = "wait_util_frame_nr",
    repeat = "repeat",
    shootDirection = "shootDirection",
@@ -52,7 +52,6 @@ export enum ActionType {
    decr = "decr",
    waitUntilAttrIs = "waitUntilAttrIs",
    
-   
    /**
     * GFX
     */
@@ -72,12 +71,28 @@ export enum ActionType {
    gfxRelease = "gfxRelease",
 }
 
+/**
+ * Attribute getters.
+ * Used to get the value of an attribute an inject that into an action that would otherwise take
+ * a integer, float, bool, or string. This is to make stuff more dynamic and flexible.
+ */
+type TAttrGetter = Readonly<{ gameObjectId?: string, attr: string }>;
+
+/**
+ * Types for primitive values.
+ * Instead of using "bool" use TBool (etc) so that an action can either take a hardcoded value
+ * or get the value from an attribute.
+ */
+export type TNumber = Readonly<number | TAttrGetter>;
+export type TString = Readonly<string | TAttrGetter>;
+export type TBool = Readonly<boolean | TAttrGetter>;
+
 /** Action types */
-export type TWait =                Readonly<{ type: ActionType.wait, frames: number }>;
+export type TWait =                Readonly<{ type: ActionType.wait, frames: TNumber }>;
 export type TWaitNextFrame =       Readonly<{ type: ActionType.waitNextFrame }>;
 export type TWaitUtilFrameNr =     Readonly<{ type: ActionType.waitUntilFrameNr, frameNr: number}>;
 export type TRepeat =              Readonly<{ type: ActionType.repeat,
-                                                times: number, actions: TAction[] }>;
+                                                times: TNumber, actions: TAction[] }>;
 export type TShootDirection =      Readonly<{ type: ActionType.shootDirection,
                                                 x: number, y: number }>;
 export type TShootTowardPlayer =   Readonly<{ type: ActionType.shootTowardPlayer }>;

--- a/src/App/services/Graphics/Graphics.ts
+++ b/src/App/services/Graphics/Graphics.ts
@@ -6,6 +6,7 @@ import type {
 } from "./IGraphics";
 import type { Vector as TVector } from "../../../math/bezier";
 
+import { ActionType as AT } from "../Enemies/actions/actionTypes";
 import { resolutionWidth } from "../../../consts";
 import { uuid } from "../../../utils/uuid";
 import { BrowserDriver } from "../../../drivers/BrowserDriver";
@@ -62,25 +63,25 @@ export class Graphics implements IGraphics {
 
    public Dispatch = (action: TGraphicsAction): TGraphicsResponse => {
       switch(action.type) {
-         case "gfxAskForElement":
+         case AT.gfxAskForElement:
             return this.actionAskForElement();
-         case "gfxSetPosition":
+         case AT.gfxSetPosition:
             return this.actionSetPosition(action);
-         case "gfxSetDiameter":
+         case AT.gfxSetDiameter:
             return this.actionSetDiameter(action);
-         case "gfxRelease":
+         case AT.gfxRelease:
             return this.actionRelease(action);
-         case "gfxSetColor":
+         case AT.gfxSetColor:
             return this.actionSetColor(action);
-         case "gfxSetShape":
+         case AT.gfxSetShape:
             return this.actionSetShape(action);
-         case "gfxSetRotation":
+         case AT.gfxSetRotation:
             return this.actionSetRotation(action);
-         case "gfxSetScale":
+         case AT.gfxSetScale:
             return this.actionSetScale(action);
-         case "gfxScrollBg":
+         case AT.gfxScrollBg:
             return this.actionScrollBg(action);
-         case "gfxFillScreen":
+         case AT.gfxFillScreen:
             return this.actionFillScreen(action);
          default: {
             // eslint-disable-next-line

--- a/src/App/services/Graphics/IGraphics.ts
+++ b/src/App/services/Graphics/IGraphics.ts
@@ -1,18 +1,11 @@
 import type { IService } from "../IService";
 import type { IDestroyable } from "../../../utils/types/IDestroyable";
-
 import type { ActionType as AT } from "../Enemies/actions/actionTypes";
+import type { LiteralUnion } from "type-fest";
 
 export type THandle = string;
 
-/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
-/**
- * The problem with eslint here is that I mix speficic strings such as "circle" with string,
- * and string is a union of all possible strings, so it's redundant. But I need to do this
- * because I want to allow any string to be used as a shape, so I can use any image as a shape,
- * but I also want to document which specific string can be sent in. Auto-completion does not work.
- */
-export type TShape =
+export type TShape = LiteralUnion<
    "none" |
    "circle" |
    "square" |
@@ -20,13 +13,13 @@ export type TShape =
    "diamondShield" |
    "octagon" |
    "explosion" |
-   "roundExplosion" |
+   "roundExplosion",
    /**
     * fallback case. allows to set ANY image. actually I should probably remove all others and
     * just have this one.
     */
-   string;
-/* eslint-enable @typescript-eslint/no-redundant-type-constituents */
+   string
+>;
 
 /***********
  * Actions *

--- a/src/App/services/Graphics/IGraphics.ts
+++ b/src/App/services/Graphics/IGraphics.ts
@@ -1,6 +1,8 @@
 import type { IService } from "../IService";
 import type { IDestroyable } from "../../../utils/types/IDestroyable";
 
+import type { ActionType as AT } from "../Enemies/actions/actionTypes";
+
 export type THandle = string;
 
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
@@ -30,42 +32,42 @@ export type TShape =
  * Actions *
  ***********/
 // Asks the Graphics Engine for a graphics element if you want one.
-export type TGfx_AskForElement = { type: "gfxAskForElement" };
+export type TGfx_AskForElement = { type: AT.gfxAskForElement };
 export type TGfx_SetPosition = {
-   type: "gfxSetPosition",
+   type: AT.gfxSetPosition,
    handle: THandle, x?: number, y?: number
 };
 export type TGfx_SetDiameter = {
-   type: "gfxSetDiameter",
+   type: AT.gfxSetDiameter,
    handle: THandle, diameter: number
 };
 // Releases a GraphicsElement, so it's free for other to pick up/ask for/claim.
-export type TGfx_Release = { type: "gfxRelease", handle: THandle };
+export type TGfx_Release = { type: AT.gfxRelease, handle: THandle };
 export type TGfx_SetColor = {
-   type: "gfxSetColor",
+   type: AT.gfxSetColor,
    handle: THandle, color: string
 };
 export type TGfx_SetShape = {
-   type: "gfxSetShape",
+   type: AT.gfxSetShape,
    handle: THandle, shape: TShape
 };
 export type TGfx_SetRotation = {
-   type: "gfxSetRotation",
+   type: AT.gfxSetRotation,
    handle: THandle, degrees: number
 };
 // TODO: This seems to be unused. Unclear purpose.
 export type TGfx_SetScale = {
-   type: "gfxSetScale",
+   type: AT.gfxSetScale,
    handle: THandle, scale: number
 };
 // scrolls the background by x, y.
 export type TGfx_ScrollBg = {
-   type: "gfxScrollBg",
+   type: AT.gfxScrollBg,
    handle: THandle, x?: number, y?: number
 };
 // make gfx cover the whole screen
 export type TGfx_FillScreen = {
-   type: "gfxFillScreen",
+   type: AT.gfxFillScreen,
    handle: THandle
 };
 

--- a/src/App/services/Graphics/variants/CachedCanvasGfx/CanvasGfx.ts
+++ b/src/App/services/Graphics/variants/CachedCanvasGfx/CanvasGfx.ts
@@ -6,6 +6,7 @@ import type {
 import type { TInitParams } from "../../../IService";
 import type { IEventsEndOfFrame } from "../../../Events/IEvents";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { Renderer } from "./Renderer";
 import { resolutionHeight, resolutionWidth, zIndices } from "../../../../../consts";
 import { uuid } from "../../../../../utils/uuid";
@@ -101,21 +102,21 @@ export class CanvasGfx implements IGraphics {
 
    public Dispatch = (action: TGraphicsAction): TGraphicsResponse => {
       switch(action.type) {
-         case "gfxAskForElement":
+         case AT.gfxAskForElement:
             return this.actionAskForElement();
-         case "gfxSetPosition":
+         case AT.gfxSetPosition:
             return this.actionSetPosition(action);
-         case "gfxSetDiameter":
+         case AT.gfxSetDiameter:
             return this.actionSetDiameter(action);
-         case "gfxRelease":
+         case AT.gfxRelease:
             return this.actionRelease(action);
-         case "gfxSetColor":
+         case AT.gfxSetColor:
             return this.actionSetColor(action);
-         case "gfxSetShape":
+         case AT.gfxSetShape:
             return this.actionSetShape(action);
-         case "gfxSetRotation":
+         case AT.gfxSetRotation:
             return this.actionSetRotation(action);
-         case "gfxSetScale":
+         case AT.gfxSetScale:
             return this.actionSetScale(action);
          default: {
             // eslint-disable-next-line

--- a/src/App/services/Graphics/variants/CachedCanvasGfx/Renderer.ts
+++ b/src/App/services/Graphics/variants/CachedCanvasGfx/Renderer.ts
@@ -129,11 +129,13 @@ export class Renderer {
          case "triangle":
          case "diamondShield":
          case "octagon":
-            images && this.drawImage(images[shape], params);
+            type x = "circle" | "square" | "triangle" | "diamondShield" | "octagon";
+            images && this.drawImage(images[shape as x], params);
             break;
          case "explosion":
          case "roundExplosion":
-            images && this.drawImage(images[shape], params);
+            type y = "explosion" | "roundExplosion";
+            images && this.drawImage(images[shape as y], params);
             break;
          default:
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/src/App/services/Graphics/variants/CanvasGfx/CanvasGfx.ts
+++ b/src/App/services/Graphics/variants/CanvasGfx/CanvasGfx.ts
@@ -6,6 +6,7 @@ import type {
 import type { TInitParams } from "../../../IService";
 import type { IEventsEndOfFrame } from "../../../Events/IEvents";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { Renderer } from "./Renderer";
 import { resolutionHeight, resolutionWidth, zIndices } from "../../../../../consts";
 import { uuid } from "../../../../../utils/uuid";
@@ -100,21 +101,21 @@ export class CanvasGfx implements IGraphics {
 
    public Dispatch = (action: TGraphicsAction): TGraphicsResponse => {
       switch(action.type) {
-         case "gfxAskForElement":
+         case AT.gfxAskForElement:
             return this.actionAskForElement();
-         case "gfxSetPosition":
+         case AT.gfxSetPosition:
             return this.actionSetPosition(action);
-         case "gfxSetDiameter":
+         case AT.gfxSetDiameter:
             return this.actionSetDiameter(action);
-         case "gfxRelease":
+         case AT.gfxRelease:
             return this.actionRelease(action);
-         case "gfxSetColor":
+         case AT.gfxSetColor:
             return this.actionSetColor(action);
-         case "gfxSetShape":
+         case AT.gfxSetShape:
             return this.actionSetShape(action);
-         case "gfxSetRotation":
+         case AT.gfxSetRotation:
             return this.actionSetRotation(action);
-         case "gfxSetScale":
+         case AT.gfxSetScale:
             return this.actionSetScale(action);
          default: {
             // eslint-disable-next-line

--- a/src/App/services/Graphics/variants/CanvasGfx/Renderer.ts
+++ b/src/App/services/Graphics/variants/CanvasGfx/Renderer.ts
@@ -98,11 +98,13 @@ export class Renderer {
          case "triangle":
          case "diamondShield":
          case "octagon":
-            images && this.drawImage(images[shape], params);
+            type x = "circle" | "square" | "triangle" | "diamondShield" | "octagon";
+            images && this.drawImage(images[shape as x], params);
             break;
          case "explosion":
          case "roundExplosion":
-            images && this.drawImage(images[shape], params);
+            type y = "explosion" | "roundExplosion";
+            images && this.drawImage(images[shape as y], params);
             break;
          default:
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/src/gameData/game1/effects/explosions.ts
+++ b/src/gameData/game1/effects/explosions.ts
@@ -9,7 +9,7 @@ export const explosion: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "explosion" },
+      { type: AT.gfxSetShape, shape: "explosion" },
       wait(40),
       // { type: "wait", frames: 40 },
       { type: AT.despawn },
@@ -22,7 +22,7 @@ export const roundExplosion: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "roundExplosion" },
+      { type: AT.gfxSetShape, shape: "roundExplosion" },
       wait(75),
       // { type: "wait", frames: 75 },
       { type: AT.despawn },

--- a/src/gameData/game1/effects/explosions.ts
+++ b/src/gameData/game1/effects/explosions.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { wait } from "../../utils";
 
 export const explosion: IEnemyJson = {
@@ -7,11 +8,11 @@ export const explosion: IEnemyJson = {
    diameter: 18,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "explosion" },
       wait(40),
       // { type: "wait", frames: 40 },
-      { type: "despawn" },
+      { type: AT.despawn },
    ],
 };
 
@@ -20,10 +21,10 @@ export const roundExplosion: IEnemyJson = {
    diameter: 40,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "roundExplosion" },
       wait(75),
       // { type: "wait", frames: 75 },
-      { type: "despawn" },
+      { type: AT.despawn },
    ],
 };

--- a/src/gameData/game1/index.ts
+++ b/src/gameData/game1/index.ts
@@ -12,7 +12,7 @@ import { cloner, clonerChild, stage2 } from "./stage2";
 import { dehealer, healer, shapeShifter, stage3 } from "./stage3";
 import { easyFlyer, stage4 } from "./stage4";
 import { layer1, layer2, layer3, parallax } from "./parallax/parallax";
-import { aqua, executor, repeatFromHp, shotSpeedFromHp, stage5 } from "./stage5";
+import { aqua, child, executor, parent, repeatFromHp, shotSpeedFromHp, stage5 } from "./stage5";
 import startScreen from "./startScreen.png";
 
 const game: TGame = {
@@ -58,6 +58,8 @@ const game: TGame = {
       aqua,
       shotSpeedFromHp,
       repeatFromHp,
+      child,
+      parent,
    ]
 };
 

--- a/src/gameData/game1/index.ts
+++ b/src/gameData/game1/index.ts
@@ -12,7 +12,7 @@ import { cloner, clonerChild, stage2 } from "./stage2";
 import { dehealer, healer, shapeShifter, stage3 } from "./stage3";
 import { easyFlyer, stage4 } from "./stage4";
 import { layer1, layer2, layer3, parallax } from "./parallax/parallax";
-import { aqua, executor, stage5 } from "./stage5";
+import { aqua, executor, repeatFromHp, shotSpeedFromHp, stage5 } from "./stage5";
 import startScreen from "./startScreen.png";
 
 const game: TGame = {
@@ -56,6 +56,8 @@ const game: TGame = {
       stage5,
       executor,
       aqua,
+      shotSpeedFromHp,
+      repeatFromHp,
    ]
 };
 

--- a/src/gameData/game1/parallax/parallax.ts
+++ b/src/gameData/game1/parallax/parallax.ts
@@ -1,13 +1,14 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
 import { forever, spawn, wait } from "@/gameData/utils";
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
 export const parallax: IEnemyJson = {
    name: "parallax",
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetColor", color: "black" },
       { type: "gfxSetShape", shape: "square" },
       { type: "gfxFillScreen" },
@@ -22,7 +23,7 @@ export const layer1: IEnemyJson = {
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "layer1.png" },
       { type: "gfxFillScreen" },
       forever(
@@ -37,7 +38,7 @@ export const layer2: IEnemyJson = {
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "layer2.png" },
       { type: "gfxFillScreen" },
       forever(
@@ -52,7 +53,7 @@ export const layer3: IEnemyJson = {
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "layer3.png" },
       { type: "gfxFillScreen" },
       forever(

--- a/src/gameData/game1/parallax/parallax.ts
+++ b/src/gameData/game1/parallax/parallax.ts
@@ -9,9 +9,9 @@ export const parallax: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetColor", color: "black" },
-      { type: "gfxSetShape", shape: "square" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetColor, color: "black" },
+      { type: AT.gfxSetShape, shape: "square" },
+      { type: AT.gfxFillScreen },
       spawn("layer1"),
       spawn("layer2"),
       spawn("layer3"),
@@ -24,11 +24,11 @@ export const layer1: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "layer1.png" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetShape, shape: "layer1.png" },
+      { type: AT.gfxFillScreen },
       forever(
          wait(1),
-         { type: "gfxScrollBg", y: -0.3 }
+         { type: AT.gfxScrollBg, y: -0.3 }
       )
    ],
 };
@@ -39,11 +39,11 @@ export const layer2: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "layer2.png" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetShape, shape: "layer2.png" },
+      { type: AT.gfxFillScreen },
       forever(
          wait(1),
-         { type: "gfxScrollBg", y: -1 }
+         { type: AT.gfxScrollBg, y: -1 }
       )
    ],
 };
@@ -54,11 +54,11 @@ export const layer3: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "layer3.png" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetShape, shape: "layer3.png" },
+      { type: AT.gfxFillScreen },
       forever(
          wait(1),
-         { type: "gfxScrollBg", y: -1.5 }
+         { type: AT.gfxScrollBg, y: -1.5 }
       )
    ],
 };

--- a/src/gameData/game1/player/player.ts
+++ b/src/gameData/game1/player/player.ts
@@ -46,7 +46,7 @@ export const player: IEnemyJson = {
       // cuz every tick the gfx rotation is set to moveDirection,
       // which is contra-intuitive. Should prolly not be set
       // automaticallt on tick, but need to be set explicitly.
-      { type: "setMoveDirection", degrees: 0 },
+      { type: AT.setMoveDirection, degrees: 0 },
       { type: AT.setAttribute, attribute: "collisionType", value: "player" },
       { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
@@ -54,15 +54,15 @@ export const player: IEnemyJson = {
       wait(1),
       { type: "gfxSetShape", shape: "diamondShield" },
       fork(forever(
-         { type: "moveAccordingToInput" },
+         { type: AT.moveAccordingToInput },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: "waitInputShoot" },
+         { type: AT.waitInputShoot },
          ...trippleShot,
       )),
       fork(forever(
-         { type: "waitInputLaser" },
+         { type: AT.waitInputLaser },
          ...laser
       )),
    ]

--- a/src/gameData/game1/player/player.ts
+++ b/src/gameData/game1/player/player.ts
@@ -1,16 +1,17 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "../../../App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
 import { forever, fork, wait } from "../../utils";
 
 type TCreateShotArgs = { moveDeltaX: number, moveDeltaY: number };
 
 const createShot = ({ moveDeltaX, moveDeltaY }: TCreateShotArgs): TAction => ({
-   type: "spawn", enemy: "playerShot",
+   type: AT.spawn, enemy: "playerShot",
    actions: [
       fork(forever(
-         { type: "moveDelta", x: moveDeltaX, y: moveDeltaY },
-         { type: "waitNextFrame" }
+         { type: AT.moveDelta, x: moveDeltaX, y: moveDeltaY },
+         { type: AT.waitNextFrame }
       ))
    ]
 });
@@ -23,12 +24,12 @@ const trippleShot: TAction[] = [
 ];
 
 const laser: TAction[] = [
-   { type: "spawn", enemy: "playerLaser", y: 15 },
-   { type: "spawn", enemy: "playerLaser", y: 10 },
-   { type: "spawn", enemy: "playerLaser", y: 5 },
-   { type: "spawn", enemy: "playerLaser", y: 0 },
-   { type: "spawn", enemy: "playerLaser", y: -5 },
-   { type: "spawn", enemy: "playerLaser", y: -10 },
+   { type: AT.spawn, enemy: "playerLaser", y: 15 },
+   { type: AT.spawn, enemy: "playerLaser", y: 10 },
+   { type: AT.spawn, enemy: "playerLaser", y: 5 },
+   { type: AT.spawn, enemy: "playerLaser", y: 0 },
+   { type: AT.spawn, enemy: "playerLaser", y: -5 },
+   { type: AT.spawn, enemy: "playerLaser", y: -10 },
    wait(3),
 ];
 
@@ -38,7 +39,7 @@ export const player: IEnemyJson = {
    hp: 1,
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetColor", color: "aqua" },
       // TODO: setMoveDirection might be a stupid name for the
       // action and the way it works might also be stupid.
@@ -46,15 +47,15 @@ export const player: IEnemyJson = {
       // which is contra-intuitive. Should prolly not be set
       // automaticallt on tick, but need to be set explicitly.
       { type: "setMoveDirection", degrees: 0 },
-      { type: "setAttribute", attribute: "collisionType", value: "player" },
-      { type: "setAttribute", attribute: "boundToWindow", value: true },
+      { type: AT.setAttribute, attribute: "collisionType", value: "player" },
+      { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
       { type: "gfxSetShape", shape: "none" },
       wait(1),
       { type: "gfxSetShape", shape: "diamondShield" },
       fork(forever(
          { type: "moveAccordingToInput" },
-         { type: "waitNextFrame" }
+         { type: AT.waitNextFrame }
       )),
       fork(forever(
          { type: "waitInputShoot" },

--- a/src/gameData/game1/player/player.ts
+++ b/src/gameData/game1/player/player.ts
@@ -40,7 +40,7 @@ export const player: IEnemyJson = {
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetColor, color: "aqua" },
       // TODO: setMoveDirection might be a stupid name for the
       // action and the way it works might also be stupid.
       // cuz every tick the gfx rotation is set to moveDirection,
@@ -50,9 +50,9 @@ export const player: IEnemyJson = {
       { type: AT.setAttribute, attribute: "collisionType", value: "player" },
       { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       wait(1),
-      { type: "gfxSetShape", shape: "diamondShield" },
+      { type: AT.gfxSetShape, shape: "diamondShield" },
       fork(forever(
          { type: AT.moveAccordingToInput },
          { type: AT.waitNextFrame }

--- a/src/gameData/game1/player/playerLaser.ts
+++ b/src/gameData/game1/player/playerLaser.ts
@@ -13,8 +13,8 @@ export const playerLaser: IEnemyJson = {
       // TODO: is points really necessary for this?
       { type: AT.setAttribute, attribute: "pointsOnDeath", value: -0.2 },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "square" },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetShape, shape: "square" },
+      { type: AT.gfxSetColor, color: "aqua" },
       parallelRace(
          forever(
             { type: AT.moveDelta, y: -30 },

--- a/src/gameData/game1/player/playerLaser.ts
+++ b/src/gameData/game1/player/playerLaser.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { forever, parallelRace, spawn, wait } from "../../utils";
 
 export const playerLaser: IEnemyJson = {
@@ -8,20 +9,20 @@ export const playerLaser: IEnemyJson = {
    diameter: 5,
    onDeathAction: spawn("explosion"),
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "playerBullet" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "playerBullet" },
       // TODO: is points really necessary for this?
-      { type: "setAttribute", attribute: "pointsOnDeath", value: -0.2 },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "pointsOnDeath", value: -0.2 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "square" },
       { type: "gfxSetColor", color: "aqua" },
       parallelRace(
          forever(
-            { type: "moveDelta", y: -30 },
-            { type: "waitNextFrame" },
+            { type: AT.moveDelta, y: -30 },
+            { type: AT.waitNextFrame },
          ),
          [
             wait(8),
-            { type: "despawn" }
+            { type: AT.despawn }
          ]
       )
    ]

--- a/src/gameData/game1/player/playerShot.ts
+++ b/src/gameData/game1/player/playerShot.ts
@@ -14,7 +14,7 @@ export const playerShot: IEnemyJson = {
       // TODO: is points really necessary for this?
       { type: AT.setAttribute, attribute: "pointsOnDeath", value: -1 },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "circle" },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetShape, shape: "circle" },
+      { type: AT.gfxSetColor, color: "aqua" },
    ],
 };

--- a/src/gameData/game1/player/playerShot.ts
+++ b/src/gameData/game1/player/playerShot.ts
@@ -2,16 +2,18 @@ import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { spawn } from "../../utils";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+
 export const playerShot: IEnemyJson = {
    name: "playerShot",
    hp: 1,
    diameter: 5,
    onDeathAction: spawn("explosion"),
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "playerBullet" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "playerBullet" },
       // TODO: is points really necessary for this?
-      { type: "setAttribute", attribute: "pointsOnDeath", value: -1 },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "pointsOnDeath", value: -1 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "circle" },
       { type: "gfxSetColor", color: "aqua" },
    ],

--- a/src/gameData/game1/shot.ts
+++ b/src/gameData/game1/shot.ts
@@ -1,12 +1,14 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+
 export const shot: IEnemyJson = {
    name: "shot",
    hp: 9999,
    diameter: 5,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "enemyBullet" },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "circle" }
    ]
 };

--- a/src/gameData/game1/shot.ts
+++ b/src/gameData/game1/shot.ts
@@ -9,6 +9,6 @@ export const shot: IEnemyJson = {
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "circle" }
+      { type: AT.gfxSetShape, shape: "circle" }
    ]
 };

--- a/src/gameData/game1/spawner.ts
+++ b/src/gameData/game1/spawner.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { fork, spawn, wait } from "../utils";
 
 export const spawner: IEnemyJson = {
@@ -11,7 +12,7 @@ export const spawner: IEnemyJson = {
          wait(3200),
          { type: "finishLevel" },
       ),
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
       // { wait: 1 },
       spawn("parallax"),

--- a/src/gameData/game1/spawner.ts
+++ b/src/gameData/game1/spawner.ts
@@ -13,7 +13,7 @@ export const spawner: IEnemyJson = {
          { type: AT.finishLevel },
       ),
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       // { wait: 1 },
       spawn("parallax"),
       spawn("player", { x: 178.5, y: 220 }),

--- a/src/gameData/game1/spawner.ts
+++ b/src/gameData/game1/spawner.ts
@@ -21,6 +21,6 @@ export const spawner: IEnemyJson = {
       // { type: "spawn", enemy: "stage2" },
       // { type: "spawn", enemy: "stage3" },
       // { type: "spawn", enemy: "stage4" },
-      // { type: "spawn", enemy: "stage5" },
+      // spawn("stage5"),
    ],
 };

--- a/src/gameData/game1/spawner.ts
+++ b/src/gameData/game1/spawner.ts
@@ -10,7 +10,7 @@ export const spawner: IEnemyJson = {
    actions: [
       fork(
          wait(3200),
-         { type: "finishLevel" },
+         { type: AT.finishLevel },
       ),
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },

--- a/src/gameData/game1/stage1.ts
+++ b/src/gameData/game1/stage1.ts
@@ -48,7 +48,7 @@ export const stage1: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       wait(120),
       aimers,
       wait(120),

--- a/src/gameData/game1/stage1.ts
+++ b/src/gameData/game1/stage1.ts
@@ -1,9 +1,12 @@
 /* eslint-disable max-len */
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 import type {
-   TAction, TMove, TShootDirection
+   TAction,
+   TMove,
+   TShootDirection
 } from "../../App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "../../App/services/Enemies/actions/actionTypes";
 import {
    attr, forever, moveToAbsolute, parallelAll, parallelRace,
    repeat, setShotSpeed, setSpeed, spawn, thrice, twice, wait
@@ -16,14 +19,14 @@ const sinusLeft = spawn("sinus", { x: 75, y: -20 });
 const sinusRight = spawn("sinus", {
    x: 280,
    y: -20,
-   actions: [{ type: "setAttribute", attribute: "right", value: true }]
+   actions: [{ type: AT.setAttribute, attribute: "right", value: true }]
 });
 
 const leftMiniBoss = spawn("firstMiniboss", { x: 118.881, y: -20 });
 const rightMiniBoss = spawn("firstMiniboss", {
    x: 237.762,
    y: -20,
-   actions: [{ type: "setAttribute", attribute: "right", value: true }]
+   actions: [{ type: AT.setAttribute, attribute: "right", value: true }]
 });
 
 const aimers = repeat(8, [
@@ -44,7 +47,7 @@ export const stage1: IEnemyJson = {
    diameter: 20,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
       wait(120),
       aimers,
@@ -67,12 +70,12 @@ export const nonShootingAimer: IEnemyJson = {
       setSpeed(1.6),
       parallelAll(
          repeat(26.25, [
-            { type: "rotate_towards_player" },
+            { type: AT.rotate_towards_player },
             wait(8)
          ]),
          forever(
-            { type: "move_according_to_speed_and_direction" },
-            { type: "waitNextFrame" }
+            { type: AT.move_according_to_speed_and_direction },
+            { type: AT.waitNextFrame }
          )
       )
    ]
@@ -80,11 +83,11 @@ export const nonShootingAimer: IEnemyJson = {
 
 //------------------------------------------------------------
 
-const moveLeft: TMove = { type: "move", frames: 80, x: -205, y: 30 };
+const moveLeft: TMove = { type: AT.move, frames: 80, x: -205, y: 30 };
 const moveRight: TMove = { ...moveLeft, x: 205 };
 
 const rotateLeft: TAction = {
-   type: "rotate_around_relative_point",
+   type: AT.rotate_around_relative_point,
    degrees: -180,
    frames: 35,
    point: { y: 31 }
@@ -93,7 +96,7 @@ const rotateRight: TAction = { ...rotateLeft, degrees: 180 };
 
 const shootWhileRotation: TAction[] = [
    wait(16),
-   { type: "shoot_toward_player" }
+   { type: AT.shootTowardPlayer }
 ];
 
 const rotateLeftAndShoot = parallelAll(
@@ -113,7 +116,7 @@ export const sinus: IEnemyJson = {
    onDeathAction: spawn("roundExplosion"),
    actions: [
       setShotSpeed(2),
-      attr("right", { is: true, yes: [{ type: "mirrorX", value: true }] }),
+      attr("right", { is: true, yes: [{ type: AT.mirrorX, value: true }] }),
       twice(
          rotateLeftAndShoot, 
          moveRight,
@@ -125,7 +128,7 @@ export const sinus: IEnemyJson = {
 
 //------------------------------------------------------------
 
-const shootDown: TShootDirection = { type: "shootDirection", x: 0, y: 1 };
+const shootDown: TShootDirection = { type: AT.shootDirection, x: 0, y: 1 };
 
 const shootingPattern = [
    wait(75),
@@ -138,9 +141,9 @@ const shootingPattern = [
       wait(55),
       setShotSpeed(2.2),
       twice(
-         { type: "shoot_toward_player" },
-         { type: "shoot_beside_player", degrees: 25 },
-         { type: "shoot_beside_player", degrees: -25 },
+         { type: AT.shootTowardPlayer },
+         { type: AT.shoot_beside_player, degrees: 25 },
+         { type: AT.shoot_beside_player, degrees: -25 },
          wait(64)
       )
    )
@@ -148,21 +151,21 @@ const shootingPattern = [
 
 const intoScreen: TAction =            moveToAbsolute({ x: 116, y: 0 , frames: 40 });
 const down1: TAction =                 moveToAbsolute({ y: 75 , frames: 52 });
-const quarterCircleDownIn: TAction =   { type: "rotate_around_relative_point", degrees: -90, frames: 39, point: { x: 25, y: -5 } };
-const quarterCircleDownOut: TAction =  { type: "rotate_around_relative_point", degrees: 90, frames: 39, point: { x: -20, y: -11 } };
+const quarterCircleDownIn: TAction =   { type: AT.rotate_around_relative_point, degrees: -90, frames: 39, point: { x: 25, y: -5 } };
+const quarterCircleDownOut: TAction =  { type: AT.rotate_around_relative_point, degrees: 90, frames: 39, point: { x: -20, y: -11 } };
 const in1: TAction =                   moveToAbsolute({ x: 139.5 , frames: 47});
 const up1: TAction =                   moveToAbsolute({ y: 11 , frames: 100 });
-const halfCircleLeftDown: TAction =    { type: "rotate_around_absolute_point", point: { y: 61 }, degrees: -180, frames: 100 };
+const halfCircleLeftDown: TAction =    { type: AT.rotate_around_absolute_point, point: { y: 61 }, degrees: -180, frames: 100 };
 const out1: TAction =                  moveToAbsolute({ x: 99.5, frames: 50 });
 const down2: TAction =                 moveToAbsolute({ y: 141, frames: 30 });
 const up2: TAction =                   moveToAbsolute({ y: 61, frames: 80 });
 const downIn: TAction =                moveToAbsolute({ x: 138.5, y: 105, frames: 40 });
-const rotateClockwise: TAction =       { type: "rotate_around_absolute_point", point: { x: 178.5 }, degrees: 360, frames: 240 };
-const rotateAntiClockwise: TAction =   { type: "rotate_around_absolute_point", point: { x: 178.5 }, degrees: -360, frames: 240 };
+const rotateClockwise: TAction =       { type: AT.rotate_around_absolute_point, point: { x: 178.5 }, degrees: 360, frames: 240 };
+const rotateAntiClockwise: TAction =   { type: AT.rotate_around_absolute_point, point: { x: 178.5 }, degrees: -360, frames: 240 };
 const downOutOfScreen: TAction =       moveToAbsolute({ x: 98.5, y: 290, frames: 210 });
 
 const movementPattern: TAction[] = [
-   attr("right", { is: true, yes: [{ type: "mirrorX", value: true }] }),
+   attr("right", { is: true, yes: [{ type: AT.mirrorX, value: true }] }),
    intoScreen,
    down1,
 
@@ -176,10 +179,10 @@ const movementPattern: TAction[] = [
    up2,                  wait(25),
    downIn,               wait(25),
 
-   attr("right", { is: true, yes: [{ type: "mirrorY", value: true }] }),
+   attr("right", { is: true, yes: [{ type: AT.mirrorY, value: true }] }),
    rotateClockwise,      wait(25),
    rotateAntiClockwise,
-   attr("right", { is: true, yes: [{ type: "mirrorY", value: false }] }),
+   attr("right", { is: true, yes: [{ type: AT.mirrorY, value: false }] }),
    wait(25),
    downOutOfScreen
 ];

--- a/src/gameData/game1/stage2.ts
+++ b/src/gameData/game1/stage2.ts
@@ -1,5 +1,7 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { attr, forever, moveToAbsolute, parallelAll, setShotSpeed, wait } from "../utils";
 import { col } from "./common";
 
@@ -8,10 +10,10 @@ export const stage2: IEnemyJson = {
    diameter: 20,
    hp: 9999,
    actions: [
-      { type: "spawn", enemy: "cloner", x: col[5], y: -20 },
+      { type: AT.spawn, enemy: "cloner", x: col[5], y: -20 },
       wait(270),
-      { type: "spawn", enemy: "cloner", x: col[2], y: -20 },
-      { type: "spawn", enemy: "cloner", x: col[8], y: -20 },
+      { type: AT.spawn, enemy: "cloner", x: col[2], y: -20 },
+      { type: AT.spawn, enemy: "cloner", x: col[8], y: -20 },
    ]
 };
 
@@ -22,17 +24,17 @@ export const cloner: IEnemyJson = {
    actions: [
       moveToAbsolute({ y: 45, frames: 150 }),
       wait(30),
-      { type: "spawn", enemy: "clonerChild" },
-      { type: "spawn", enemy: "clonerChild", actions: [
-         { type: "setAttribute", attribute: "mirrorX", value: true }
+      { type: AT.spawn, enemy: "clonerChild" },
+      { type: AT.spawn, enemy: "clonerChild", actions: [
+         { type: AT.setAttribute, attribute: "mirrorX", value: true }
       ] },
       wait(80),
-      { type: "spawn", enemy: "clonerChild", actions: [
-         { type: "setAttribute", attribute: "mirrorY", value: true }
+      { type: AT.spawn, enemy: "clonerChild", actions: [
+         { type: AT.setAttribute, attribute: "mirrorY", value: true }
       ] },
-      { type: "spawn", enemy: "clonerChild", actions: [
-         { type: "setAttribute", attribute: "mirrorX", value: true },
-         { type: "setAttribute", attribute: "mirrorY", value: true }
+      { type: AT.spawn, enemy: "clonerChild", actions: [
+         { type: AT.setAttribute, attribute: "mirrorX", value: true },
+         { type: AT.setAttribute, attribute: "mirrorY", value: true }
       ]},
    ]
 };
@@ -42,15 +44,15 @@ export const clonerChild: IEnemyJson = {
    hp: 10,
    diameter: 18,
    actions: [
-      attr("mirrorX", { is: true, yes: [{ type: "mirrorX", value: true }] }),
-      attr("mirrorY", { is: true, yes: [{ type: "mirrorY", value: true }] }),
+      attr("mirrorX", { is: true, yes: [{ type: AT.mirrorX, value: true }] }),
+      attr("mirrorY", { is: true, yes: [{ type: AT.mirrorY, value: true }] }),
       setShotSpeed(1.5),
       parallelAll(
-         { type: "move", x: -45, y: -20, frames: 65 },
+         { type: AT.move, x: -45, y: -20, frames: 65 },
          [
             wait(60),
             forever(
-               { type: "shootDirection", x: 0, y: 1},
+               { type: AT.shootDirection, x: 0, y: 1},
                wait(40)
             ),
          ],

--- a/src/gameData/game1/stage3.ts
+++ b/src/gameData/game1/stage3.ts
@@ -9,7 +9,7 @@ export const stage3: IEnemyJson = {
    diameter: 20,
    hp: 9999,
    actions: [
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       { type: AT.spawn, enemy: "shapeShifter", x: col[5], y: row[5] },
       { type: AT.spawn, enemy: "healer", x: col[4], y: row[4] },
       { type: AT.spawn, enemy: "dehealer", x: col[6], y: row[4] },
@@ -23,15 +23,15 @@ export const shapeShifter: IEnemyJson = {
    onDeathAction: { type: AT.spawn, enemy: "shapeShifter", y: -20 },
    actions: [
       forever(
-         { type: "gfxSetShape", shape: "circle" },
+         { type: AT.gfxSetShape, shape: "circle" },
          wait(60),
-         { type: "gfxSetShape", shape: "square" },
+         { type: AT.gfxSetShape, shape: "square" },
          wait(60),
-         { type: "gfxSetShape", shape: "triangle" },
+         { type: AT.gfxSetShape, shape: "triangle" },
          wait(60),
-         { type: "gfxSetShape", shape: "diamondShield" },
+         { type: AT.gfxSetShape, shape: "diamondShield" },
          wait(60),
-         { type: "gfxSetShape", shape: "octagon" },
+         { type: AT.gfxSetShape, shape: "octagon" },
          wait(60),
       )
    ]

--- a/src/gameData/game1/stage3.ts
+++ b/src/gameData/game1/stage3.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { attr, forever, wait } from "../utils";
 import { col, row } from "./common";
 
@@ -9,9 +10,9 @@ export const stage3: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: "gfxSetShape", shape: "none" },
-      { type: "spawn", enemy: "shapeShifter", x: col[5], y: row[5] },
-      { type: "spawn", enemy: "healer", x: col[4], y: row[4] },
-      { type: "spawn", enemy: "dehealer", x: col[6], y: row[4] },
+      { type: AT.spawn, enemy: "shapeShifter", x: col[5], y: row[5] },
+      { type: AT.spawn, enemy: "healer", x: col[4], y: row[4] },
+      { type: AT.spawn, enemy: "dehealer", x: col[6], y: row[4] },
    ]
 };
 
@@ -19,7 +20,7 @@ export const shapeShifter: IEnemyJson = {
    name: "shapeShifter",
    diameter: 30,
    hp: 100,
-   onDeathAction: { type: "spawn", enemy: "shapeShifter", y: -20 },
+   onDeathAction: { type: AT.spawn, enemy: "shapeShifter", y: -20 },
    actions: [
       forever(
          { type: "gfxSetShape", shape: "circle" },
@@ -41,12 +42,12 @@ export const healer: IEnemyJson = {
    diameter: 30,
    hp: 50,
    actions: [
-      { type: "setAttribute", attribute: "hp", value: 25 },
+      { type: AT.setAttribute, attribute: "hp", value: 25 },
       forever(
          wait(10),
          attr("hp", {
             is: 50,
-            no: [{ type: "incr", attribute: "hp" }]
+            no: [{ type: AT.incr, attribute: "hp" }]
          })
       )
    ]
@@ -59,7 +60,7 @@ export const dehealer: IEnemyJson = {
    actions: [
       forever(
          wait(10),
-         { type: "decr", attribute: "hp" }
+         { type: AT.decr, attribute: "hp" }
       )
    ]
 };

--- a/src/gameData/game1/stage4.ts
+++ b/src/gameData/game1/stage4.ts
@@ -1,11 +1,12 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 import type { TAction } from "../../App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "../../App/services/Enemies/actions/actionTypes";
 import { forever } from "../utils";
 import { col, row } from "./common";
 
 const makeEasyFlyer = ({ x = col[1], y = -30}: { x?: number, y?: number}): TAction => ({
-   type: "spawn", enemy: "easyFlyer",
+   type: AT.spawn, enemy: "easyFlyer",
    x,
    y,
 });
@@ -51,43 +52,43 @@ const makeEasyFlyer = ({ x = col[1], y = -30}: { x?: number, y?: number}): TActi
 // ];
 
 const wave3: TAction[] = [
-   { type: "spawn", enemy: "easyFlyer", x: -100, y: 0, actions: [
+   { type: AT.spawn, enemy: "easyFlyer", x: -100, y: 0, actions: [
       { type: "setMoveDirection", degrees: 140 }
    ] },
-   { type: "spawn", enemy: "easyFlyer", x: -50, y: -50, actions: [
+   { type: AT.spawn, enemy: "easyFlyer", x: -50, y: -50, actions: [
       { type: "setMoveDirection", degrees: 135 }
    ] },
-   { type: "spawn", enemy: "easyFlyer", x: 0, y: -100, actions: [
+   { type: AT.spawn, enemy: "easyFlyer", x: 0, y: -100, actions: [
       { type: "setMoveDirection", degrees: 135 }
    ] },
-   { type: "wait", frames: 30 },
-   { type: "spawn", enemy: "easyFlyer", x: col[9], y: row[-1], actions: [
+   { type: AT.wait, frames: 30 },
+   { type: AT.spawn, enemy: "easyFlyer", x: col[9], y: row[-1], actions: [
       { type: "setMoveDirection", degrees: -135 }
    ] },
-   { type: "spawn", enemy: "easyFlyer", x: col[10], y: row[0], actions: [
+   { type: AT.spawn, enemy: "easyFlyer", x: col[10], y: row[0], actions: [
       { type: "setMoveDirection", degrees: -135 }
    ] },
-   { type: "spawn", enemy: "easyFlyer", x: col[11], y: row[1], actions: [
+   { type: AT.spawn, enemy: "easyFlyer", x: col[11], y: row[1], actions: [
       { type: "setMoveDirection", degrees: -135 }
    ] },
-   { type: "wait", frames: 60 },
+   { type: AT.wait, frames: 60 },
 ];
 
 const wave4: TAction[] = [
-   { type: "repeat", times: 5, actions: [
+   { type: AT.repeat, times: 5, actions: [
       makeEasyFlyer({ x: col[1], y: -20 }),
       makeEasyFlyer({ x: col[3], y: -20 }),
       makeEasyFlyer({ x: col[5], y: -20 }),
       makeEasyFlyer({ x: col[7], y: -20 }),
       makeEasyFlyer({ x: col[9], y: -20 }),
-      { type: "wait", frames: 80 },
+      { type: AT.wait, frames: 80 },
       makeEasyFlyer({ x: col[0], y: -20 }),
       makeEasyFlyer({ x: col[2], y: -20 }),
       makeEasyFlyer({ x: col[4], y: -20 }),
       makeEasyFlyer({ x: col[6], y: -20 }),
       makeEasyFlyer({ x: col[8], y: -20 }),
       makeEasyFlyer({ x: col[10], y: -20 }),
-      { type: "wait", frames: 80 },
+      { type: AT.wait, frames: 80 },
    ]},
 ];
 
@@ -101,7 +102,7 @@ export const stage4: IEnemyJson = {
       // - do: *wave2
       // - wait: 240
       ...wave3,
-      { type: "wait", frames: 240 },
+      { type: AT.wait, frames: 240 },
       ...wave4,
    ],
 };
@@ -111,11 +112,11 @@ export const easyFlyer: IEnemyJson = {
    diameter: 29,
    hp: 5,
    actions: [
-      { type: "setSpeed", pixelsPerFrame: 1.17 },
+      { type: AT.setSpeed, pixelsPerFrame: 1.17 },
       { type: "gfxSetColor", color: "green" },
       forever(
-         { type: "move_according_to_speed_and_direction" },
-         { type: "waitNextFrame" },
+         { type: AT.move_according_to_speed_and_direction },
+         { type: AT.waitNextFrame },
       )
    ],
 };

--- a/src/gameData/game1/stage4.ts
+++ b/src/gameData/game1/stage4.ts
@@ -53,23 +53,23 @@ const makeEasyFlyer = ({ x = col[1], y = -30}: { x?: number, y?: number}): TActi
 
 const wave3: TAction[] = [
    { type: AT.spawn, enemy: "easyFlyer", x: -100, y: 0, actions: [
-      { type: "setMoveDirection", degrees: 140 }
+      { type: AT.setMoveDirection, degrees: 140 }
    ] },
    { type: AT.spawn, enemy: "easyFlyer", x: -50, y: -50, actions: [
-      { type: "setMoveDirection", degrees: 135 }
+      { type: AT.setMoveDirection, degrees: 135 }
    ] },
    { type: AT.spawn, enemy: "easyFlyer", x: 0, y: -100, actions: [
-      { type: "setMoveDirection", degrees: 135 }
+      { type: AT.setMoveDirection, degrees: 135 }
    ] },
    { type: AT.wait, frames: 30 },
    { type: AT.spawn, enemy: "easyFlyer", x: col[9], y: row[-1], actions: [
-      { type: "setMoveDirection", degrees: -135 }
+      { type: AT.setMoveDirection, degrees: -135 }
    ] },
    { type: AT.spawn, enemy: "easyFlyer", x: col[10], y: row[0], actions: [
-      { type: "setMoveDirection", degrees: -135 }
+      { type: AT.setMoveDirection, degrees: -135 }
    ] },
    { type: AT.spawn, enemy: "easyFlyer", x: col[11], y: row[1], actions: [
-      { type: "setMoveDirection", degrees: -135 }
+      { type: AT.setMoveDirection, degrees: -135 }
    ] },
    { type: AT.wait, frames: 60 },
 ];

--- a/src/gameData/game1/stage4.ts
+++ b/src/gameData/game1/stage4.ts
@@ -113,7 +113,7 @@ export const easyFlyer: IEnemyJson = {
    hp: 5,
    actions: [
       { type: AT.setSpeed, pixelsPerFrame: 1.17 },
-      { type: "gfxSetColor", color: "green" },
+      { type: AT.gfxSetColor, color: "green" },
       forever(
          { type: AT.move_according_to_speed_and_direction },
          { type: AT.waitNextFrame },

--- a/src/gameData/game1/stage5.ts
+++ b/src/gameData/game1/stage5.ts
@@ -38,7 +38,7 @@ export const aqua: IEnemyJson = {
       { type: "gfxSetColor", color: "aqua" },
       { type: AT.setShotSpeed, pixelsPerFrame: 2 },
       forever(
-         { type:"waitUntilAttrIs", gameObjectId: "global", attr: "aquaShoot", is: true },
+         { type: AT.waitUntilAttrIs, gameObjectId: "global", attr: "aquaShoot", is: true },
          { type: AT.shootDirection, x: 0, y: 1 },
          wait(1),
       )

--- a/src/gameData/game1/stage5.ts
+++ b/src/gameData/game1/stage5.ts
@@ -1,7 +1,7 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { forever, spawn, wait } from "../utils";
+import { forever, repeat, spawn, wait } from "../utils";
 import { col, row } from "./common";
 
 export const stage5: IEnemyJson = {
@@ -12,6 +12,42 @@ export const stage5: IEnemyJson = {
       { type: AT.gfxSetShape, shape: "none" },
       spawn("aqua", { x: col[3], y: row[3] }),
       spawn("executor", { x: col[5], y: row[5] }),
+      spawn("shotSpeedFromHp", { x: col[7], y: row[5] }),
+      spawn("repeatFromHp", { x: col[8], y: row[5] }),
+   ],
+};
+
+// Proves that attribute getter work with wait action.
+export const shotSpeedFromHp: IEnemyJson = {
+   name: "shotSpeedFromHp",
+   diameter: 20,
+   hp: 50,
+   actions: [
+      { type: AT.gfxSetShape, shape: "octagon" },
+      { type: AT.gfxSetColor, color: "red" },
+      { type: AT.setShotSpeed, pixelsPerFrame: 1.8 },
+      forever(
+         wait({ attr: "hp" }),
+         { type: AT.shootDirection, x: 0, y: -1 },
+      )
+   ],
+};
+
+// Proves that attribute getter work with repeat action.
+export const repeatFromHp: IEnemyJson = {
+   name: "repeatFromHp",
+   diameter: 20,
+   hp: 50,
+   actions: [
+      { type: AT.gfxSetShape, shape: "octagon" },
+      { type: AT.gfxSetColor, color: "red" },
+      { type: AT.setShotSpeed, pixelsPerFrame: 1.8 },
+      forever(
+         repeat({ attr: "hp" }, [
+            wait(1)
+         ]),
+         { type: AT.shootDirection, x: 0, y: -1 },
+      )
    ],
 };
 

--- a/src/gameData/game1/stage5.ts
+++ b/src/gameData/game1/stage5.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { forever, spawn, wait } from "../utils";
 import { col, row } from "./common";
 
@@ -21,9 +22,9 @@ export const executor: IEnemyJson = {
    actions: [
       { type: "gfxSetColor", color: "green" },
       forever(
-         { type: "setAttribute", gameObjectId: "global", attribute: "aquaShoot", value: true },
+         { type: AT.setAttribute, gameObjectId: "global", attribute: "aquaShoot", value: true },
          wait(1),
-         { type: "setAttribute", gameObjectId: "global", attribute: "aquaShoot", value: false },
+         { type: AT.setAttribute, gameObjectId: "global", attribute: "aquaShoot", value: false },
          wait(35),
       )
    ],
@@ -35,10 +36,10 @@ export const aqua: IEnemyJson = {
    hp: 100_000,
    actions: [
       { type: "gfxSetColor", color: "aqua" },
-      { type: "setShotSpeed", pixelsPerFrame: 2 },
+      { type: AT.setShotSpeed, pixelsPerFrame: 2 },
       forever(
          { type:"waitUntilAttrIs", gameObjectId: "global", attr: "aquaShoot", is: true },
-         { type: "shootDirection", x: 0, y: 1 },
+         { type: AT.shootDirection, x: 0, y: 1 },
          wait(1),
       )
    ],

--- a/src/gameData/game1/stage5.ts
+++ b/src/gameData/game1/stage5.ts
@@ -10,10 +10,11 @@ export const stage5: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.gfxSetShape, shape: "none" },
-      spawn("aqua", { x: col[3], y: row[3] }),
-      spawn("executor", { x: col[5], y: row[5] }),
-      spawn("shotSpeedFromHp", { x: col[7], y: row[5] }),
-      spawn("repeatFromHp", { x: col[8], y: row[5] }),
+      spawn("aqua", { x: col[1], y: row[3] }),
+      spawn("executor", { x: col[2], y: row[5] }),
+      spawn("shotSpeedFromHp", { x: col[3], y: row[5] }),
+      spawn("repeatFromHp", { x: col[4], y: row[5] }),
+      spawn("parent", { x: col[7], y: row[5] }),
    ],
 };
 
@@ -78,5 +79,31 @@ export const aqua: IEnemyJson = {
          { type: AT.shootDirection, x: 0, y: 1 },
          wait(1),
       )
+   ],
+};
+
+/**
+ * Proves that children have parents (parentId is stored in attribute "parentId" on the child).
+ * Shooting on 
+ */
+export const child: IEnemyJson = {
+   name: "child",
+   diameter: 20,
+   hp: 100_000,
+   actions: [
+      { type: AT.gfxSetColor, color: "aqua" },
+      { type: AT.waitUntilAttrIs, gameObjectId: { attr: "parentId" }, attr: "hp", is: 0 },
+      { type: AT.die },
+   ],
+};
+export const parent: IEnemyJson = {
+   name: "parent",
+   diameter: 25,
+   hp: 5,
+   actions: [
+      { type: AT.gfxSetColor, color: "red" },
+      spawn("child", { x: -30,   y: -30 }),
+      spawn("child", { x: 0,     y: -30 }),
+      spawn("child", { x: 30,    y: -30 }),
    ],
 };

--- a/src/gameData/game1/stage5.ts
+++ b/src/gameData/game1/stage5.ts
@@ -9,7 +9,7 @@ export const stage5: IEnemyJson = {
    diameter: 20,
    hp: 9999,
    actions: [
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       spawn("aqua", { x: col[3], y: row[3] }),
       spawn("executor", { x: col[5], y: row[5] }),
    ],
@@ -20,7 +20,7 @@ export const executor: IEnemyJson = {
    diameter: 30,
    hp: 100_000,
    actions: [
-      { type: "gfxSetColor", color: "green" },
+      { type: AT.gfxSetColor, color: "green" },
       forever(
          { type: AT.setAttribute, gameObjectId: "global", attribute: "aquaShoot", value: true },
          wait(1),
@@ -35,7 +35,7 @@ export const aqua: IEnemyJson = {
    diameter: 30,
    hp: 100_000,
    actions: [
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetColor, color: "aqua" },
       { type: AT.setShotSpeed, pixelsPerFrame: 2 },
       forever(
          { type: AT.waitUntilAttrIs, gameObjectId: "global", attr: "aquaShoot", is: true },

--- a/src/gameData/game2/effects/explosions.ts
+++ b/src/gameData/game2/effects/explosions.ts
@@ -9,7 +9,7 @@ export const explosion: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "explosion" },
+      { type: AT.gfxSetShape, shape: "explosion" },
       wait(40),
       // { type: "wait", frames: 40 },
       { type: AT.despawn },
@@ -22,7 +22,7 @@ export const roundExplosion: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "roundExplosion" },
+      { type: AT.gfxSetShape, shape: "roundExplosion" },
       wait(75),
       // { type: "wait", frames: 75 },
       { type: AT.despawn },

--- a/src/gameData/game2/effects/explosions.ts
+++ b/src/gameData/game2/effects/explosions.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { wait } from "../../utils";
 
 export const explosion: IEnemyJson = {
@@ -7,11 +8,11 @@ export const explosion: IEnemyJson = {
    diameter: 18,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "explosion" },
       wait(40),
       // { type: "wait", frames: 40 },
-      { type: "despawn" },
+      { type: AT.despawn },
    ],
 };
 
@@ -20,10 +21,10 @@ export const roundExplosion: IEnemyJson = {
    diameter: 40,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "roundExplosion" },
       wait(75),
       // { type: "wait", frames: 75 },
-      { type: "despawn" },
+      { type: AT.despawn },
    ],
 };

--- a/src/gameData/game2/enemies/boss.ts
+++ b/src/gameData/game2/enemies/boss.ts
@@ -1,6 +1,7 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 import type { TAction } from "@/App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
    forever,
    parallelAll,
@@ -13,45 +14,45 @@ import { col } from "../common";
 const shootInAll8Directions = (shootSpeed: number): TAction[] => [
    // blink to signal it's about to shoot
    { type: "gfxSetColor", color: "aqua" },
-   { type: "wait", frames: 10 },
+   { type: AT.wait, frames: 10 },
    { type: "gfxSetColor", color: "red" },
-   { type: "wait", frames: 10 },
+   { type: AT.wait, frames: 10 },
 
-   { type: "setShotSpeed", pixelsPerFrame: shootSpeed },
+   { type: AT.setShotSpeed, pixelsPerFrame: shootSpeed },
 
-   { type: "shootDirection", x: 1, y: -1 },
-   { type: "shootDirection", x: 1, y: 0 },
-   { type: "shootDirection", x: 1, y: 1 },
-   { type: "shootDirection", x: 0, y: 1 },
-   { type: "shootDirection", x: -1, y: 1 },
-   { type: "shootDirection", x: -1, y: 0 },
-   { type: "shootDirection", x: -1, y: -1 },
-   { type: "shootDirection", x: 0, y: -1 },
+   { type: AT.shootDirection, x: 1, y: -1 },
+   { type: AT.shootDirection, x: 1, y: 0 },
+   { type: AT.shootDirection, x: 1, y: 1 },
+   { type: AT.shootDirection, x: 0, y: 1 },
+   { type: AT.shootDirection, x: -1, y: 1 },
+   { type: AT.shootDirection, x: -1, y: 0 },
+   { type: AT.shootDirection, x: -1, y: -1 },
+   { type: AT.shootDirection, x: 0, y: -1 },
 ];
 
 const shotsAtPlayer: TAction[] = [
    repeat(4, [
-      { type: "setShotSpeed", pixelsPerFrame: 0.9 },
-      { type: "shoot_toward_player" }, 
-      { type: "wait", frames: 70 }
+      { type: AT.setShotSpeed, pixelsPerFrame: 0.9 },
+      { type: AT.shootTowardPlayer }, 
+      { type: AT.wait, frames: 70 }
    ]),
 
    repeat(10, [
-      { type: "setShotSpeed", pixelsPerFrame: 1.0 },
-      { type: "shoot_toward_player" }, 
-      { type: "wait", frames: 28 }
+      { type: AT.setShotSpeed, pixelsPerFrame: 1.0 },
+      { type: AT.shootTowardPlayer }, 
+      { type: AT.wait, frames: 28 }
    ]),
 
    repeat(16, [
-      { type: "setShotSpeed", pixelsPerFrame: 1.1 },
-      { type: "shoot_toward_player" }, 
-      { type: "wait", frames: 8 }
+      { type: AT.setShotSpeed, pixelsPerFrame: 1.1 },
+      { type: AT.shootTowardPlayer }, 
+      { type: AT.wait, frames: 8 }
    ]),
 
    forever(
-      { type: "setShotSpeed", pixelsPerFrame: 1.1 },
-      { type: "shoot_toward_player" }, 
-      { type: "wait", frames: 8 }
+      { type: AT.setShotSpeed, pixelsPerFrame: 1.1 },
+      { type: AT.shootTowardPlayer }, 
+      { type: AT.wait, frames: 8 }
    ),
 ];
 
@@ -62,18 +63,18 @@ const shootingPattern: TAction[] = [
          wait(7 * 60),
          repeat(5, [
             ...shootInAll8Directions(0.8),
-            { type: "wait", frames: 300 }
+            { type: AT.wait, frames: 300 }
          ]),
          forever(
             ...shootInAll8Directions(0.8),
-            { type: "wait", frames: 150 }
+            { type: AT.wait, frames: 150 }
          ),
       ]
    )
 ];
 
 const movePattern: TAction[] = [
-   { type: "moveToAbsolute", frames: 60 * 7.5, moveTo: { x: col[5] }}
+   { type: AT.moveToAbsolute, frames: 60 * 7.5, moveTo: { x: col[5] }}
 ];
 
 export const boss: IEnemyJson = {
@@ -84,7 +85,7 @@ export const boss: IEnemyJson = {
    actions: [
       { type: "gfxSetShape", shape: "stage2/circle.png" },
       ...movePattern,
-      { type: "setAttribute", attribute: "hp", value: 70 }, // In fact make it immortal until now.
+      { type: AT.setAttribute, attribute: "hp", value: 70 }, // In fact make it immortal until now.
       parallelAll(
          shootingPattern
       )

--- a/src/gameData/game2/enemies/boss.ts
+++ b/src/gameData/game2/enemies/boss.ts
@@ -13,9 +13,9 @@ import { col } from "../common";
 
 const shootInAll8Directions = (shootSpeed: number): TAction[] => [
    // blink to signal it's about to shoot
-   { type: "gfxSetColor", color: "aqua" },
+   { type: AT.gfxSetColor, color: "aqua" },
    { type: AT.wait, frames: 10 },
-   { type: "gfxSetColor", color: "red" },
+   { type: AT.gfxSetColor, color: "red" },
    { type: AT.wait, frames: 10 },
 
    { type: AT.setShotSpeed, pixelsPerFrame: shootSpeed },
@@ -83,7 +83,7 @@ export const boss: IEnemyJson = {
    diameter: 40,
    onDeathAction: spawn("bossCorpse"),
    actions: [
-      { type: "gfxSetShape", shape: "stage2/circle.png" },
+      { type: AT.gfxSetShape, shape: "stage2/circle.png" },
       ...movePattern,
       { type: AT.setAttribute, attribute: "hp", value: 70 }, // In fact make it immortal until now.
       parallelAll(

--- a/src/gameData/game2/enemies/bossCorpse.ts
+++ b/src/gameData/game2/enemies/bossCorpse.ts
@@ -1,6 +1,7 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "@/App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
    parallelAll,
    spawn,
@@ -32,14 +33,14 @@ export const bossCorpse: IEnemyJson = {
    diameter: 18,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "explosion" },
       parallelAll(
          explodeInAllDirections(8, 3),
          explodeInAllDirections(24, 5),
          explodeInAllDirections(16, 15),
       ),
-      { type: "wait", frames: 60 * 3 },
+      { type: AT.wait, frames: 60 * 3 },
       { type: "finishLevel" }
    ],
 };

--- a/src/gameData/game2/enemies/bossCorpse.ts
+++ b/src/gameData/game2/enemies/bossCorpse.ts
@@ -34,7 +34,7 @@ export const bossCorpse: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "explosion" },
+      { type: AT.gfxSetShape, shape: "explosion" },
       parallelAll(
          explodeInAllDirections(8, 3),
          explodeInAllDirections(24, 5),

--- a/src/gameData/game2/enemies/bossCorpse.ts
+++ b/src/gameData/game2/enemies/bossCorpse.ts
@@ -41,6 +41,6 @@ export const bossCorpse: IEnemyJson = {
          explodeInAllDirections(16, 15),
       ),
       { type: AT.wait, frames: 60 * 3 },
-      { type: "finishLevel" }
+      { type: AT.finishLevel }
    ],
 };

--- a/src/gameData/game2/enemies/dot.ts
+++ b/src/gameData/game2/enemies/dot.ts
@@ -3,6 +3,7 @@ import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 import {
    spawn,
 } from "@/gameData/utils";
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
 export const dot: IEnemyJson = {
    name: "dot",
@@ -10,6 +11,6 @@ export const dot: IEnemyJson = {
    diameter: 20,
    onDeathAction: spawn("roundExplosion"),
    actions: [
-      { type: "gfxSetShape", shape: "stage2/circle.png" },
+      { type: AT.gfxSetShape, shape: "stage2/circle.png" },
    ]
 };

--- a/src/gameData/game2/enemies/nonShootingAimer.ts
+++ b/src/gameData/game2/enemies/nonShootingAimer.ts
@@ -1,6 +1,7 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
 import { forever, parallelAll, repeat, setSpeed, spawn, wait } from "@/gameData/utils";
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
 export const nonShootingAimer: IEnemyJson = {
    name: "nonShootingAimer",
@@ -11,12 +12,12 @@ export const nonShootingAimer: IEnemyJson = {
       setSpeed(1.6),
       parallelAll(
          repeat(26.25, [
-            { type: "rotate_towards_player" },
+            { type: AT.rotate_towards_player },
             wait(8)
          ]),
          forever(
-            { type: "move_according_to_speed_and_direction" },
-            { type: "waitNextFrame" }
+            { type: AT.move_according_to_speed_and_direction },
+            { type: AT.waitNextFrame }
          )
       )
    ]

--- a/src/gameData/game2/enemies/spinningDots.ts
+++ b/src/gameData/game2/enemies/spinningDots.ts
@@ -1,6 +1,7 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 import type { TAction } from "@/App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
    forever,
    fork,
@@ -10,7 +11,7 @@ import {
 const dist = 27;
 
 const rotate = ({ x, y }: { x?: number, y?: number }): TAction => ({
-   type: "rotate_around_relative_point",
+   type: AT.rotate_around_relative_point,
    degrees: -360 * 15,
    frames: 200 * 4.0 * 15,
    point: { x, y }
@@ -22,7 +23,7 @@ export const spinningDots: IEnemyJson = {
    diameter: 5,
    onDeathAction: spawn("roundExplosion"),
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
       { type: "gfxSetShape", shape: "stage2/circle.png" },
       { type: "gfxSetColor", color: "aqua" },
@@ -30,8 +31,8 @@ export const spinningDots: IEnemyJson = {
       spawn("dot", {
          actions: [
             fork(forever(
-               { type: "moveDelta", x: -0.55 },
-               { type: "waitNextFrame" },
+               { type: AT.moveDelta, x: -0.55 },
+               { type: AT.waitNextFrame },
             )),
          ]
       }),
@@ -41,8 +42,8 @@ export const spinningDots: IEnemyJson = {
          x: dist,
          actions: [
             fork(forever(
-               { type: "moveDelta", x: -0.55 },
-               { type: "waitNextFrame" },
+               { type: AT.moveDelta, x: -0.55 },
+               { type: AT.waitNextFrame },
             )),
             fork(rotate({ x: -dist }))
          ]
@@ -52,8 +53,8 @@ export const spinningDots: IEnemyJson = {
          x: dist*2,
          actions: [
             fork(forever(
-               { type: "moveDelta", x: -0.55 },
-               { type: "waitNextFrame" },
+               { type: AT.moveDelta, x: -0.55 },
+               { type: AT.waitNextFrame },
             )),
             fork(rotate({ x: -(dist*2) }))]
       }),
@@ -63,8 +64,8 @@ export const spinningDots: IEnemyJson = {
          x: -dist,
          actions: [
             fork(forever(
-               { type: "moveDelta", x: -0.55 },
-               { type: "waitNextFrame" },
+               { type: AT.moveDelta, x: -0.55 },
+               { type: AT.waitNextFrame },
             )),
             fork(rotate({ x: dist }))]
       }),
@@ -73,11 +74,11 @@ export const spinningDots: IEnemyJson = {
          x: -(dist*2),
          actions: [
             fork(forever(
-               { type: "moveDelta", x: -0.55 },
-               { type: "waitNextFrame" },
+               { type: AT.moveDelta, x: -0.55 },
+               { type: AT.waitNextFrame },
             )),
             fork(rotate({ x: dist*2 }))]
       }),
-      { type: "despawn" }
+      { type: AT.despawn }
    ]
 };

--- a/src/gameData/game2/enemies/spinningDots.ts
+++ b/src/gameData/game2/enemies/spinningDots.ts
@@ -24,9 +24,9 @@ export const spinningDots: IEnemyJson = {
    onDeathAction: spawn("roundExplosion"),
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
-      { type: "gfxSetShape", shape: "stage2/circle.png" },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetShape, shape: "none" },
+      { type: AT.gfxSetShape, shape: "stage2/circle.png" },
+      { type: AT.gfxSetColor, color: "aqua" },
       // center
       spawn("dot", {
          actions: [

--- a/src/gameData/game2/enemies/traceDot.ts
+++ b/src/gameData/game2/enemies/traceDot.ts
@@ -1,6 +1,7 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
 import { wait } from "@/gameData/utils";
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
 export const traceDot: IEnemyJson = {
    name: "traceDot",
@@ -8,6 +9,6 @@ export const traceDot: IEnemyJson = {
    diameter: 5,
    actions: [
       wait(3 * 60),
-      { type: "despawn" }
+      { type: AT.despawn }
    ]
 };

--- a/src/gameData/game2/parallax/parallax.ts
+++ b/src/gameData/game2/parallax/parallax.ts
@@ -9,9 +9,9 @@ export const parallax: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetColor", color: "black" },
-      { type: "gfxSetShape", shape: "square" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetColor, color: "black" },
+      { type: AT.gfxSetShape, shape: "square" },
+      { type: AT.gfxFillScreen },
       spawn("layer1"),
       spawn("layer2"),
       spawn("layer3"),
@@ -24,11 +24,11 @@ export const layer1: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "layer1.png" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetShape, shape: "layer1.png" },
+      { type: AT.gfxFillScreen },
       forever(
          wait(1),
-         { type: "gfxScrollBg", x: 0.3 }
+         { type: AT.gfxScrollBg, x: 0.3 }
       )
    ],
 };
@@ -39,11 +39,11 @@ export const layer2: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "layer2.png" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetShape, shape: "layer2.png" },
+      { type: AT.gfxFillScreen },
       forever(
          wait(1),
-         { type: "gfxScrollBg", x: 1 }
+         { type: AT.gfxScrollBg, x: 1 }
       )
    ],
 };
@@ -54,11 +54,11 @@ export const layer3: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "layer3.png" },
-      { type: "gfxFillScreen" },
+      { type: AT.gfxSetShape, shape: "layer3.png" },
+      { type: AT.gfxFillScreen },
       forever(
          wait(1),
-         { type: "gfxScrollBg", x: 1.5 }
+         { type: AT.gfxScrollBg, x: 1.5 }
       )
    ],
 };

--- a/src/gameData/game2/parallax/parallax.ts
+++ b/src/gameData/game2/parallax/parallax.ts
@@ -1,13 +1,14 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
 import { forever, spawn, wait } from "@/gameData/utils";
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
 export const parallax: IEnemyJson = {
    name: "parallax",
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetColor", color: "black" },
       { type: "gfxSetShape", shape: "square" },
       { type: "gfxFillScreen" },
@@ -22,7 +23,7 @@ export const layer1: IEnemyJson = {
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "layer1.png" },
       { type: "gfxFillScreen" },
       forever(
@@ -37,7 +38,7 @@ export const layer2: IEnemyJson = {
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "layer2.png" },
       { type: "gfxFillScreen" },
       forever(
@@ -52,7 +53,7 @@ export const layer3: IEnemyJson = {
    diameter: 240,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "layer3.png" },
       { type: "gfxFillScreen" },
       forever(

--- a/src/gameData/game2/player/player.ts
+++ b/src/gameData/game2/player/player.ts
@@ -1,17 +1,18 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "../../../App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
 import { forever, fork, wait } from "../../utils";
 
 type TCreateShotArgs = { moveDeltaX: number, moveDeltaY: number };
 
 const createShot = ({ moveDeltaX, moveDeltaY }: TCreateShotArgs): TAction => ({
-   type: "spawn",
+   type: AT.spawn,
    enemy: "playerShot",
    actions: [
       fork(forever(
-         { type: "moveDelta", x: moveDeltaX, y: moveDeltaY },
-         { type: "waitNextFrame" }
+         { type: AT.moveDelta, x: moveDeltaX, y: moveDeltaY },
+         { type: AT.waitNextFrame }
       ))
    ]
 });
@@ -27,7 +28,7 @@ export const player: IEnemyJson = {
    hp: 1,
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetColor", color: "aqua" },
       // TODO: setMoveDirection might be a stupid name for the
       // action and the way it works might also be stupid.
@@ -35,8 +36,8 @@ export const player: IEnemyJson = {
       // which is contra-intuitive. Should prolly not be set
       // automaticallt on tick, but need to be set explicitly.
       { type: "setMoveDirection", degrees: 0 },
-      { type: "setAttribute", attribute: "collisionType", value: "player" },
-      { type: "setAttribute", attribute: "boundToWindow", value: true },
+      { type: AT.setAttribute, attribute: "collisionType", value: "player" },
+      { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
       { type: "gfxSetShape", shape: "none" },
       { type: "setMoveDirection", degrees: 90 },
@@ -44,7 +45,7 @@ export const player: IEnemyJson = {
       { type: "gfxSetShape", shape: "stage2/player.png" },
       fork(forever(
          { type: "moveAccordingToInput" },
-         { type: "waitNextFrame" }
+         { type: AT.waitNextFrame }
       )),
       fork(forever(
          { type: "waitInputShoot" },

--- a/src/gameData/game2/player/player.ts
+++ b/src/gameData/game2/player/player.ts
@@ -29,7 +29,7 @@ export const player: IEnemyJson = {
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetColor, color: "aqua" },
       // TODO: setMoveDirection might be a stupid name for the
       // action and the way it works might also be stupid.
       // cuz every tick the gfx rotation is set to moveDirection,
@@ -39,10 +39,10 @@ export const player: IEnemyJson = {
       { type: AT.setAttribute, attribute: "collisionType", value: "player" },
       { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       { type: AT.setMoveDirection, degrees: 90 },
       wait(1),
-      { type: "gfxSetShape", shape: "stage2/player.png" },
+      { type: AT.gfxSetShape, shape: "stage2/player.png" },
       fork(forever(
          { type: AT.moveAccordingToInput },
          { type: AT.waitNextFrame }

--- a/src/gameData/game2/player/player.ts
+++ b/src/gameData/game2/player/player.ts
@@ -35,20 +35,20 @@ export const player: IEnemyJson = {
       // cuz every tick the gfx rotation is set to moveDirection,
       // which is contra-intuitive. Should prolly not be set
       // automaticallt on tick, but need to be set explicitly.
-      { type: "setMoveDirection", degrees: 0 },
+      { type: AT.setMoveDirection, degrees: 0 },
       { type: AT.setAttribute, attribute: "collisionType", value: "player" },
       { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
       { type: "gfxSetShape", shape: "none" },
-      { type: "setMoveDirection", degrees: 90 },
+      { type: AT.setMoveDirection, degrees: 90 },
       wait(1),
       { type: "gfxSetShape", shape: "stage2/player.png" },
       fork(forever(
-         { type: "moveAccordingToInput" },
+         { type: AT.moveAccordingToInput },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: "waitInputShoot" },
+         { type: AT.waitInputShoot },
          ...trippleShot,
       )),
    ]

--- a/src/gameData/game2/player/playerShot.ts
+++ b/src/gameData/game2/player/playerShot.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { spawn } from "../../utils";
 
 export const playerShot: IEnemyJson = {
@@ -8,10 +9,10 @@ export const playerShot: IEnemyJson = {
    diameter: 5,
    onDeathAction: spawn("explosion"),
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "playerBullet" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "playerBullet" },
       // TODO: is points really necessary for this?
-      { type: "setAttribute", attribute: "pointsOnDeath", value: -1 },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "pointsOnDeath", value: -1 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "circle" },
       { type: "gfxSetColor", color: "aqua" },
    ],

--- a/src/gameData/game2/player/playerShot.ts
+++ b/src/gameData/game2/player/playerShot.ts
@@ -13,7 +13,7 @@ export const playerShot: IEnemyJson = {
       // TODO: is points really necessary for this?
       { type: AT.setAttribute, attribute: "pointsOnDeath", value: -1 },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "circle" },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetShape, shape: "circle" },
+      { type: AT.gfxSetColor, color: "aqua" },
    ],
 };

--- a/src/gameData/game2/shot.ts
+++ b/src/gameData/game2/shot.ts
@@ -1,12 +1,14 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+
 export const shot: IEnemyJson = {
    name: "shot",
    hp: 9999,
    diameter: 5,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "enemyBullet" },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "circle" }
    ]
 };

--- a/src/gameData/game2/shot.ts
+++ b/src/gameData/game2/shot.ts
@@ -9,6 +9,6 @@ export const shot: IEnemyJson = {
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "circle" }
+      { type: AT.gfxSetShape, shape: "circle" }
    ]
 };

--- a/src/gameData/game2/spawner.ts
+++ b/src/gameData/game2/spawner.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { fork, spawn, wait } from "../utils";
 import { col, row } from "./common";
 
@@ -12,7 +13,7 @@ export const spawner: IEnemyJson = {
          wait(300 * 60),
          { type: "finishLevel" },
       ),
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
       // { wait: 1 },
       spawn("parallax"),

--- a/src/gameData/game2/spawner.ts
+++ b/src/gameData/game2/spawner.ts
@@ -11,7 +11,7 @@ export const spawner: IEnemyJson = {
    actions: [
       fork(
          wait(300 * 60),
-         { type: "finishLevel" },
+         { type: AT.finishLevel },
       ),
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },

--- a/src/gameData/game2/spawner.ts
+++ b/src/gameData/game2/spawner.ts
@@ -14,7 +14,7 @@ export const spawner: IEnemyJson = {
          { type: AT.finishLevel },
       ),
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       // { wait: 1 },
       spawn("parallax"),
       spawn("player", { x: col[1], y: row[5] }),

--- a/src/gameData/game2/stage.ts
+++ b/src/gameData/game2/stage.ts
@@ -6,13 +6,14 @@ import {
 } from "../utils";
 import { col, row } from "./common";
 import { aimersWave } from "./waves/aimers";
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
 export const stage: IEnemyJson = {
    name: "stage",
    diameter: 20,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
 
       // aimers wave

--- a/src/gameData/game2/stage.ts
+++ b/src/gameData/game2/stage.ts
@@ -14,7 +14,7 @@ export const stage: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
 
       // aimers wave
       wait(1 * 60),

--- a/src/gameData/game3/effects/explosions.ts
+++ b/src/gameData/game3/effects/explosions.ts
@@ -9,7 +9,7 @@ export const explosion: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "explosion" },
+      { type: AT.gfxSetShape, shape: "explosion" },
       wait(40),
       // { type: "wait", frames: 40 },
       { type: AT.despawn },
@@ -22,7 +22,7 @@ export const roundExplosion: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "roundExplosion" },
+      { type: AT.gfxSetShape, shape: "roundExplosion" },
       wait(75),
       // { type: "wait", frames: 75 },
       { type: AT.despawn },

--- a/src/gameData/game3/effects/explosions.ts
+++ b/src/gameData/game3/effects/explosions.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { wait } from "../../utils";
 
 export const explosion: IEnemyJson = {
@@ -7,11 +8,11 @@ export const explosion: IEnemyJson = {
    diameter: 18,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "explosion" },
       wait(40),
       // { type: "wait", frames: 40 },
-      { type: "despawn" },
+      { type: AT.despawn },
    ],
 };
 
@@ -20,10 +21,10 @@ export const roundExplosion: IEnemyJson = {
    diameter: 40,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "roundExplosion" },
       wait(75),
       // { type: "wait", frames: 75 },
-      { type: "despawn" },
+      { type: AT.despawn },
    ],
 };

--- a/src/gameData/game3/kamikaze/kamikazeCorpse.ts
+++ b/src/gameData/game3/kamikaze/kamikazeCorpse.ts
@@ -1,12 +1,13 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { wait } from "../../utils";
 
 export const kamikaze: IEnemyJson = {
    name: "kamikaze",
    diameter: 20,
    hp: 1,
-   onDeathAction: { type: "spawn", enemy: "kamikazeCorpse" },
+   onDeathAction: { type: AT.spawn, enemy: "kamikazeCorpse" },
    actions: [
       { type: "gfxSetShape", shape: "octagon" },
       { type: "gfxSetColor", color: "red" },
@@ -20,17 +21,17 @@ export const kamikazeCorpse: IEnemyJson = {
    diameter: 20,
    hp: 1,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
-      { type: "setShotSpeed", pixelsPerFrame: 0.9 },
-      { type: "shootDirection", x: 1, y: -1 },
-      { type: "shootDirection", x: 1, y: 0 },
-      { type: "shootDirection", x: 1, y: 1 },
-      { type: "shootDirection", x: 0, y: 1 },
-      { type: "shootDirection", x: -1, y: 1 },
-      { type: "shootDirection", x: -1, y: 0 },
-      { type: "shootDirection", x: -1, y: -1 },
-      { type: "shootDirection", x: 0, y: -1 },
-      { type: "despawn" },
+      { type: AT.setShotSpeed, pixelsPerFrame: 0.9 },
+      { type: AT.shootDirection, x: 1, y: -1 },
+      { type: AT.shootDirection, x: 1, y: 0 },
+      { type: AT.shootDirection, x: 1, y: 1 },
+      { type: AT.shootDirection, x: 0, y: 1 },
+      { type: AT.shootDirection, x: -1, y: 1 },
+      { type: AT.shootDirection, x: -1, y: 0 },
+      { type: AT.shootDirection, x: -1, y: -1 },
+      { type: AT.shootDirection, x: 0, y: -1 },
+      { type: AT.despawn },
    ],
 };

--- a/src/gameData/game3/kamikaze/kamikazeCorpse.ts
+++ b/src/gameData/game3/kamikaze/kamikazeCorpse.ts
@@ -9,8 +9,8 @@ export const kamikaze: IEnemyJson = {
    hp: 1,
    onDeathAction: { type: AT.spawn, enemy: "kamikazeCorpse" },
    actions: [
-      { type: "gfxSetShape", shape: "octagon" },
-      { type: "gfxSetColor", color: "red" },
+      { type: AT.gfxSetShape, shape: "octagon" },
+      { type: AT.gfxSetColor, color: "red" },
       wait(90),
       // { type: "die" },
    ],
@@ -22,7 +22,7 @@ export const kamikazeCorpse: IEnemyJson = {
    hp: 1,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       { type: AT.setShotSpeed, pixelsPerFrame: 0.9 },
       { type: AT.shootDirection, x: 1, y: -1 },
       { type: AT.shootDirection, x: 1, y: 0 },

--- a/src/gameData/game3/kamikaze/sinus.ts
+++ b/src/gameData/game3/kamikaze/sinus.ts
@@ -52,7 +52,7 @@ export const sinus: IEnemyJson = {
       { type: AT.spawn, enemy: "kamikazeCorpse" },
    ),
    actions: [
-      { type: "gfxSetShape", shape: "octagon" },
+      { type: AT.gfxSetShape, shape: "octagon" },
       { type: AT.setShotSpeed, pixelsPerFrame: 1.5 },
       attr("right", { is: true, yes: [{ type: AT.mirrorX, value: true }] }),
       twice(

--- a/src/gameData/game3/kamikaze/sinus.ts
+++ b/src/gameData/game3/kamikaze/sinus.ts
@@ -1,10 +1,11 @@
 import type { TAction, TMove } from "../../../App/services/Enemies/actions/actionTypes";
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
 import { Do, attr, parallelAll, twice, wait } from "../../utils";
 
 const moveLeft: TMove = {
-   type: "move",
+   type: AT.move,
    frames: 80,
    x: -205,
    y: 30,
@@ -16,7 +17,7 @@ const moveRight: TMove = {
 };
 
 const rotateLeft: TAction = {
-   type: "rotate_around_relative_point",
+   type: AT.rotate_around_relative_point,
    degrees: -180,
    frames: 35,
    point: { y: 31 },
@@ -29,7 +30,7 @@ const rotateRight = {
 
 const shootWhileRotation: TAction[] = [
    wait(16),
-   { type: "shoot_toward_player" },
+   { type: AT.shootTowardPlayer },
 ];
 
 const rotateLeftAndShoot = parallelAll(
@@ -47,13 +48,13 @@ export const sinus: IEnemyJson = {
    hp: 1,
    diameter: 24,
    onDeathAction: Do(
-      { type: "spawn", enemy: "roundExplosion" },
-      { type: "spawn", enemy: "kamikazeCorpse" },
+      { type: AT.spawn, enemy: "roundExplosion" },
+      { type: AT.spawn, enemy: "kamikazeCorpse" },
    ),
    actions: [
       { type: "gfxSetShape", shape: "octagon" },
-      { type: "setShotSpeed", pixelsPerFrame: 1.5 },
-      attr("right", { is: true, yes: [{ type: "mirrorX", value: true }] }),
+      { type: AT.setShotSpeed, pixelsPerFrame: 1.5 },
+      attr("right", { is: true, yes: [{ type: AT.mirrorX, value: true }] }),
       twice(
          rotateLeftAndShoot,
          moveRight,

--- a/src/gameData/game3/pacifistStage.ts
+++ b/src/gameData/game3/pacifistStage.ts
@@ -1,20 +1,21 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 import type { TSpawn } from "../../App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT} from "../../App/services/Enemies/actions/actionTypes";
 import { Do, repeat, wait } from "../utils";
 
 const sinusLeft: TSpawn = {
-   type: "spawn", enemy: "sinus",
+   type: AT.spawn, enemy: "sinus",
    x: 75,
    y: -20,
 };
 
 const sinusRight: TSpawn = {
-   type: "spawn", enemy: "sinus",
+   type: AT.spawn, enemy: "sinus",
    x: 280,
    y: -20,
    actions: [
-      { type: "setAttribute", attribute: "right", value: true }
+      { type: AT.setAttribute, attribute: "right", value: true }
    ],
 };
 
@@ -28,7 +29,7 @@ export const pacifistStage: IEnemyJson = {
    diameter: 20,
    hp: 9999,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
       wait(120),
       sinuses,

--- a/src/gameData/game3/pacifistStage.ts
+++ b/src/gameData/game3/pacifistStage.ts
@@ -30,7 +30,7 @@ export const pacifistStage: IEnemyJson = {
    hp: 9999,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       wait(120),
       sinuses,
    ],

--- a/src/gameData/game3/player/player.ts
+++ b/src/gameData/game3/player/player.ts
@@ -46,7 +46,7 @@ export const player: IEnemyJson = {
       // cuz every tick the gfx rotation is set to moveDirection,
       // which is contra-intuitive. Should prolly not be set
       // automaticallt on tick, but need to be set explicitly.
-      { type: "setMoveDirection", degrees: 0 },
+      { type: AT.setMoveDirection, degrees: 0 },
       { type: AT.setAttribute, attribute: "collisionType", value: "player" },
       { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
@@ -54,15 +54,15 @@ export const player: IEnemyJson = {
       wait(1),
       { type: "gfxSetShape", shape: "diamondShield" },
       fork(forever(
-         { type: "moveAccordingToInput" },
+         { type: AT.moveAccordingToInput },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: "waitInputShoot" },
+         { type: AT.waitInputShoot },
          ...trippleShot,
       )),
       fork(forever(
-         { type: "waitInputLaser" },
+         { type: AT.waitInputLaser },
          ...laser,
       )),
    ]

--- a/src/gameData/game3/player/player.ts
+++ b/src/gameData/game3/player/player.ts
@@ -1,16 +1,17 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "../../../App/services/Enemies/actions/actionTypes";
 
+import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
 import { forever, fork, wait } from "../../utils";
 
 type TCreateShotArgs = { moveDeltaX: number, moveDeltaY: number };
 
 const createShot = ({ moveDeltaX, moveDeltaY }: TCreateShotArgs): TAction => ({
-   type: "spawn", enemy: "playerShot",
+   type: AT.spawn, enemy: "playerShot",
    actions: [
       fork(forever(
-         { type: "moveDelta", x: moveDeltaX, y: moveDeltaY },
-         { type: "waitNextFrame" }
+         { type: AT.moveDelta, x: moveDeltaX, y: moveDeltaY },
+         { type: AT.waitNextFrame }
       ))
    ]
 });
@@ -23,12 +24,12 @@ const trippleShot: TAction[] = [
 ];
 
 const laser: TAction[] = [
-   { type: "spawn", enemy: "playerLaser", y: 15 },
-   { type: "spawn", enemy: "playerLaser", y: 10 },
-   { type: "spawn", enemy: "playerLaser", y: 5 },
-   { type: "spawn", enemy: "playerLaser", y: 0 },
-   { type: "spawn", enemy: "playerLaser", y: -5 },
-   { type: "spawn", enemy: "playerLaser", y: -10 },
+   { type: AT.spawn, enemy: "playerLaser", y: 15 },
+   { type: AT.spawn, enemy: "playerLaser", y: 10 },
+   { type: AT.spawn, enemy: "playerLaser", y: 5 },
+   { type: AT.spawn, enemy: "playerLaser", y: 0 },
+   { type: AT.spawn, enemy: "playerLaser", y: -5 },
+   { type: AT.spawn, enemy: "playerLaser", y: -10 },
    wait(3),
 ];
 
@@ -38,7 +39,7 @@ export const player: IEnemyJson = {
    hp: 1,
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetColor", color: "aqua" },
       // TODO: setMoveDirection might be a stupid name for the
       // action and the way it works might also be stupid.
@@ -46,15 +47,15 @@ export const player: IEnemyJson = {
       // which is contra-intuitive. Should prolly not be set
       // automaticallt on tick, but need to be set explicitly.
       { type: "setMoveDirection", degrees: 0 },
-      { type: "setAttribute", attribute: "collisionType", value: "player" },
-      { type: "setAttribute", attribute: "boundToWindow", value: true },
+      { type: AT.setAttribute, attribute: "collisionType", value: "player" },
+      { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
       { type: "gfxSetShape", shape: "none" },
       wait(1),
       { type: "gfxSetShape", shape: "diamondShield" },
       fork(forever(
          { type: "moveAccordingToInput" },
-         { type: "waitNextFrame" }
+         { type: AT.waitNextFrame }
       )),
       fork(forever(
          { type: "waitInputShoot" },

--- a/src/gameData/game3/player/player.ts
+++ b/src/gameData/game3/player/player.ts
@@ -40,7 +40,7 @@ export const player: IEnemyJson = {
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetColor, color: "aqua" },
       // TODO: setMoveDirection might be a stupid name for the
       // action and the way it works might also be stupid.
       // cuz every tick the gfx rotation is set to moveDirection,
@@ -50,9 +50,9 @@ export const player: IEnemyJson = {
       { type: AT.setAttribute, attribute: "collisionType", value: "player" },
       { type: AT.setAttribute, attribute: "boundToWindow", value: true },
       // The following line is just a hack to hide the player initially.
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       wait(1),
-      { type: "gfxSetShape", shape: "diamondShield" },
+      { type: AT.gfxSetShape, shape: "diamondShield" },
       fork(forever(
          { type: AT.moveAccordingToInput },
          { type: AT.waitNextFrame }

--- a/src/gameData/game3/player/playerLaser.ts
+++ b/src/gameData/game3/player/playerLaser.ts
@@ -13,8 +13,8 @@ export const playerLaser: IEnemyJson = {
       // TODO: is points really necessary for this?
       { type: AT.setAttribute, attribute: "pointsOnDeath", value: -0.2 },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "square" },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetShape, shape: "square" },
+      { type: AT.gfxSetColor, color: "aqua" },
       parallelRace(
          forever(
             { type: AT.moveDelta, y: -30 },

--- a/src/gameData/game3/player/playerLaser.ts
+++ b/src/gameData/game3/player/playerLaser.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { forever, parallelRace, spawn, wait } from "../../utils";
 
 export const playerLaser: IEnemyJson = {
@@ -8,20 +9,20 @@ export const playerLaser: IEnemyJson = {
    diameter: 5,
    onDeathAction: spawn("explosion"),
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "playerBullet" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "playerBullet" },
       // TODO: is points really necessary for this?
-      { type: "setAttribute", attribute: "pointsOnDeath", value: -0.2 },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "pointsOnDeath", value: -0.2 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "square" },
       { type: "gfxSetColor", color: "aqua" },
       parallelRace(
          forever(
-            { type: "moveDelta", y: -30 },
-            { type: "waitNextFrame" },
+            { type: AT.moveDelta, y: -30 },
+            { type: AT.waitNextFrame },
          ),
          [
             wait(8),
-            { type: "despawn" }
+            { type: AT.despawn }
          ]
       ),
    ]

--- a/src/gameData/game3/player/playerShot.ts
+++ b/src/gameData/game3/player/playerShot.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import { spawn } from "../../utils";
 
 export const playerShot: IEnemyJson = {
@@ -8,10 +9,10 @@ export const playerShot: IEnemyJson = {
    diameter: 5,
    onDeathAction: spawn("explosion"),
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "playerBullet" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "playerBullet" },
       // TODO: is points really necessary for this?
-      { type: "setAttribute", attribute: "pointsOnDeath", value: -1 },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "pointsOnDeath", value: -1 },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "circle" },
       { type: "gfxSetColor", color: "aqua" },
    ],

--- a/src/gameData/game3/player/playerShot.ts
+++ b/src/gameData/game3/player/playerShot.ts
@@ -13,7 +13,7 @@ export const playerShot: IEnemyJson = {
       // TODO: is points really necessary for this?
       { type: AT.setAttribute, attribute: "pointsOnDeath", value: -1 },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "circle" },
-      { type: "gfxSetColor", color: "aqua" },
+      { type: AT.gfxSetShape, shape: "circle" },
+      { type: AT.gfxSetColor, color: "aqua" },
    ],
 };

--- a/src/gameData/game3/shot.ts
+++ b/src/gameData/game3/shot.ts
@@ -1,12 +1,14 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+
 export const shot: IEnemyJson = {
    name: "shot",
    hp: 9999,
    diameter: 5,
    actions: [
-      { type: "setAttribute", attribute: "collisionType", value: "enemyBullet" },
-      { type: "setAttribute", attribute: "points", value: 0 },
+      { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
+      { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: "gfxSetShape", shape: "circle" }
    ]
 };

--- a/src/gameData/game3/shot.ts
+++ b/src/gameData/game3/shot.ts
@@ -9,6 +9,6 @@ export const shot: IEnemyJson = {
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
       { type: AT.setAttribute, attribute: "points", value: 0 },
-      { type: "gfxSetShape", shape: "circle" }
+      { type: AT.gfxSetShape, shape: "circle" }
    ]
 };

--- a/src/gameData/game3/spawner.ts
+++ b/src/gameData/game3/spawner.ts
@@ -17,7 +17,7 @@ export const spawner: IEnemyJson = {
       //    { type: "finishLevel" }
       // ),
       { type: AT.setAttribute, attribute: "collisionType", value: "none" },
-      { type: "gfxSetShape", shape: "none" },
+      { type: AT.gfxSetShape, shape: "none" },
       // { wait: 1 },
       spawn("player", { x: 178.5, y: 220 }),
       spawn("pacifistStage")

--- a/src/gameData/game3/spawner.ts
+++ b/src/gameData/game3/spawner.ts
@@ -1,5 +1,6 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
+import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
    // fork,
    spawn,
@@ -15,7 +16,7 @@ export const spawner: IEnemyJson = {
       //    wait(100),
       //    { type: "finishLevel" }
       // ),
-      { type: "setAttribute", attribute: "collisionType", value: "none" },
+      { type: AT.setAttribute, attribute: "collisionType", value: "none" },
       { type: "gfxSetShape", shape: "none" },
       // { wait: 1 },
       spawn("player", { x: 178.5, y: 220 }),

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -1,7 +1,9 @@
 import type {
    TAction, TAttrIs, TDo, TFork, TMoveToAbsolute, TRepeat, TSetShotSpeed, TSetSpeed,
-   TSpawn, TWait, TparallelAll,TparallelRace
+   TSpawn, TWait, TparallelAll, TparallelRace
 } from "../App/services/Enemies/actions/actionTypes";
+
+import { ActionType as AT } from "../App/services/Enemies/actions/actionTypes";
 
 type TAttrParams = {
    is: TAttrIs["is"];
@@ -9,7 +11,7 @@ type TAttrParams = {
    no?: TAttrIs["no"];
 };
 export const attr = (attrName: TAttrIs["attrName"], { is, yes, no }: TAttrParams): TAttrIs => ({
-   type: "attrIs",
+   type: AT.attrIs,
    attrName,
    is,
    yes,
@@ -18,12 +20,12 @@ export const attr = (attrName: TAttrIs["attrName"], { is, yes, no }: TAttrParams
 
 // first caps because `do` is a reserved word in js.
 export const Do = (...actions: TAction[]): TDo => ({
-   type: "do",
+   type: AT.do,
    acns: actions
 });
 
 export const forever = (...actions: TAction[]): TRepeat => ({
-   type: "repeat",
+   type: AT.repeat,
    times: 100_000_000,
    actions
 });
@@ -35,29 +37,29 @@ export const fork = (...actions: TAction[]): TFork => ({
 
 type TMoveToAbsParams = { x?: number, y?: number, frames: number};
 export const moveToAbsolute = ({ x, y, frames }: TMoveToAbsParams): TMoveToAbsolute => ({
-   type: "moveToAbsolute",
+   type: AT.moveToAbsolute,
    moveTo: { x, y },
    frames
 });
 
 export const parallelAll = (...actions: (TAction|TAction[])[]): TparallelAll => ({
-   type: "parallelAll",
+   type: AT.parallelAll,
    actionsLists: actions.map(acns => Array.isArray(acns) ? acns : [acns])
 });
 
 export const parallelRace = (...actions: (TAction|TAction[])[]): TparallelRace => ({
-   type: "parallelRace",
+   type: AT.parallelRace,
    actionsLists: actions.map(acn => Array.isArray(acn) ? acn : [acn])
 });
 
 export const repeat = (times: number, actions: TAction[]): TRepeat => ({
-   type: "repeat",
+   type: AT.repeat,
    times,
    actions
 });
 
 export const setSpeed = (pixelsPerFrame: number): TSetSpeed => ({
-   type: "setSpeed",
+   type: AT.setSpeed,
    pixelsPerFrame
 });
 
@@ -67,7 +69,7 @@ type TSpawnParams = {
    actions?: (TAction)[]
 }
 export const spawn = (enemy: string, params?: TSpawnParams): TSpawn => ({
-   type: "spawn",
+   type: AT.spawn,
    enemy,
    x: params?.x,
    y: params?.y,
@@ -75,7 +77,7 @@ export const spawn = (enemy: string, params?: TSpawnParams): TSpawn => ({
 });
 
 export const setShotSpeed = (pixelsPerFrame: number): TSetShotSpeed => ({
-   type: "setShotSpeed",
+   type: AT.setShotSpeed,
    pixelsPerFrame
 });
 
@@ -83,4 +85,4 @@ export const thrice = (...actions: TAction[]): TRepeat => repeat(3, actions);
 
 export const twice = (...actions: TAction[]): TRepeat => repeat(2, actions);
 
-export const wait = (frames: number): TWait => ({ type: "wait", frames });
+export const wait = (frames: number): TWait => ({ type: AT.wait, frames });

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -1,5 +1,5 @@
 import type {
-   TAction, TAttrIs, TDo, TFork, TMoveToAbsolute, TRepeat, TSetShotSpeed, TSetSpeed,
+   TAction, TAttrIs, TDo, TFork, TMoveToAbsolute, TNumber, TRepeat, TSetShotSpeed, TSetSpeed,
    TSpawn, TWait, TparallelAll, TparallelRace
 } from "../App/services/Enemies/actions/actionTypes";
 
@@ -52,7 +52,7 @@ export const parallelRace = (...actions: (TAction|TAction[])[]): TparallelRace =
    actionsLists: actions.map(acn => Array.isArray(acn) ? acn : [acn])
 });
 
-export const repeat = (times: number, actions: TAction[]): TRepeat => ({
+export const repeat = (times: TNumber, actions: TAction[]): TRepeat => ({
    type: AT.repeat,
    times,
    actions
@@ -85,4 +85,4 @@ export const thrice = (...actions: TAction[]): TRepeat => repeat(3, actions);
 
 export const twice = (...actions: TAction[]): TRepeat => repeat(2, actions);
 
-export const wait = (frames: number): TWait => ({ type: AT.wait, frames });
+export const wait = (frames: TNumber): TWait => ({ type: AT.wait, frames });

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -31,7 +31,7 @@ export const forever = (...actions: TAction[]): TRepeat => ({
 });
 
 export const fork = (...actions: TAction[]): TFork => ({
-   type: "fork",
+   type: AT.fork,
    actions
 });
 


### PR DESCRIPTION
- Improved attributes so that some actions can grab either hardcoded values (string, bool, number) or they could grab the value from an attribute.
  - Only some actions have this functionality at this point. I'll have to add it to all other actions eventually.
  - GameObjects that are spawned automatically gets a `parentId` (who spawned them) in their attributes.
  - Added som examples in stage1/stage5:
    - Shows that killing parent can auto-kill children.
