### PR TITLE
Allow player to have hp, i.e. not die after just one hit.

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -301,12 +301,8 @@ buttons though.
   For every frame I would save a delta.
 
 * What cool shit could I do with actions now?
-   * I would be cool if instead of dying automatically and auto-triggering Game Over,
-     I could could trigger Game Over manually.
-     It would be cool if it was possible to give the player several lifes this way, like
-     decrementing a counter and then fully die when it eaches zero.
-     Actually, maybe I could replace `onDeathAction` with `waitUntilAttrIs` action so that I wait
-     until `hp` is 0.
+     It would be cool if it was possible to give the player several lifes, like
+     decrementing a counter and then fully die when it reaches zero.
 
    * Points could be entirely managed by enemies themselves (in onHit callback or something).
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -323,3 +323,6 @@ buttons though.
    ```
 
 * TODO: Now I have broken the player invincibility setting.
+
+* Collision detection does some duplicate collision detection, can be improved. Checked bullets
+  against player collisions twice.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -294,6 +294,12 @@ buttons though.
   `TNumber | { position: "relative" | "absolute", value: TNumber }`, although that looks a bit
   complicated so I dunno.
 
+* Maybe every GameObject should auto-get a `type` attribute which is the `name`
+  (inconsistent naming) set when creating a GameObject (IEnemyJSON) when creating a game/level.
+
+* When I have most of the stuff in Attributes, I should use Attributes in e2e test instead:
+  For every frame I would save a delta.
+
 * What cool shit could I do with actions now?
    * I would be cool if instead of dying automatically and auto-triggering Game Over,
      I could could trigger Game Over manually.
@@ -315,3 +321,5 @@ buttons though.
       parallelRace(waitUntilAttrIs(flag, "phase3"), [some, actions]),
    ]
    ```
+
+* TODO: Now I have broken the player invincibility setting.

--- a/src/App/services/Collisions/Collisions.ts
+++ b/src/App/services/Collisions/Collisions.ts
@@ -109,7 +109,7 @@ export class Collisions implements IService {
          this.eventsCollisions.dispatchEvent({ type: "collisions", collisions });
       }
       
-      const enemiesThatWereHit = enemies.reduce<string[]>((acc, enemy) => {
+      const enemiesHitByPlayerBullets = enemies.reduce<string[]>((acc, enemy) => {
          const collision = this.calcCollisions({
             doesThis: enemy,
             collideWithThese: playerBullets
@@ -118,12 +118,28 @@ export class Collisions implements IService {
          return collision.collided ? [...acc, enemy.id, collision.collidedWithId] : acc;
       }, []);
 
+      /** TODO: I think there are some collisions that are calculatd twice. */
+      // Bullets hitting the player should be able to explode/despawn for example.
+      const enemyBulletsThatHitPlayer = enemyBullets.reduce<string[]>((acc, enemyBullet) => {
+         const collision = this.calcCollisions({
+            doesThis: enemyBullet,
+            collideWithThese: [player]
+         });
+         return collision.collided ? [...acc, enemyBullet.id] : acc;
+      }, []);
+
       const endTime = BrowserDriver.PerformanceNow();
       this.accumulatedTime += endTime - startTime;
 
       // Only send event if there were collisions.
-      if (enemiesThatWereHit.length > 0) {
-         const collisions = { enemiesThatWereHit };
+      if (enemiesHitByPlayerBullets.length > 0) {
+         const collisions = { enemiesThatWereHit: enemiesHitByPlayerBullets };
+         this.eventsCollisions.dispatchEvent({ type: "collisions", collisions });
+      }
+
+      // Only send event if there were collisions.
+      if (enemyBulletsThatHitPlayer.length > 0) {
+         const collisions = { enemiesThatWereHit: enemyBulletsThatHitPlayer };
          this.eventsCollisions.dispatchEvent({ type: "collisions", collisions });
       }
    };

--- a/src/App/services/E2eTest/E2eTest.ts
+++ b/src/App/services/E2eTest/E2eTest.ts
@@ -62,7 +62,7 @@ export class E2eTest implements IE2eTest {
    };
 
    private onEvent = (event: TGameEvent | TPointsEvent | TCollisionsEvent) => {
-      if (event.type === "player_died") {
+      if (event.type === "gameOver") {
          // This should actually trigger for very kind of END OF GAME scenario.
          console.log("E2eTest: Test succeeded.");
          const millis = (BrowserDriver.PerformanceNow() - this.startTime);

--- a/src/App/services/E2eTest/e2ehistory.ts
+++ b/src/App/services/E2eTest/e2ehistory.ts
@@ -26050,6 +26050,19 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "player"
+      },
+      {
+         "type": "collisions",
+         "collisions": {
+            "enemiesThatWereHit": [
+               "shot-63"
+            ]
+         }
+      },
+      {
+         "type": "add_points",
+         "points": 0,
+         "enemy": "shot"
       }
    ],
    "2097": [
@@ -26090,14 +26103,6 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      },
-      {
-         "type": "collisions",
-         "collisions": {
-            "enemiesThatWereHit": [
-               "player-0"
-            ]
-         }
       },
       {
          "type": "collisions",

--- a/src/App/services/E2eTest/e2ehistory.ts
+++ b/src/App/services/E2eTest/e2ehistory.ts
@@ -54,7 +54,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "136": [
+   "135": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -89,7 +89,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "144": [
+   "143": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -102,6 +102,21 @@ export const recordedHistory = {
       }
    ],
    "151": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -123,21 +138,6 @@ export const recordedHistory = {
       }
    ],
    "152": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -170,9 +170,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "160": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -184,7 +182,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "168": [
+   "167": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -224,7 +222,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "176": [
+   "175": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -290,7 +288,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "184": [
+   "183": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -356,12 +354,14 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "192": [
+   "191": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      },
+      }
+   ],
+   "192": [
       {
          "type": "collisions",
          "collisions": {
@@ -441,9 +441,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "200": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -478,7 +476,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "208": [
+   "207": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -539,7 +537,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "216": [
+   "215": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -551,7 +549,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "224": [
+   "223": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -588,6 +586,16 @@ export const recordedHistory = {
    ],
    "231": [
       {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
          "type": "collisions",
          "collisions": {
             "enemiesThatWereHit": [
@@ -608,16 +616,6 @@ export const recordedHistory = {
       }
    ],
    "232": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -650,9 +648,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "240": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -692,7 +688,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "248": [
+   "247": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -732,7 +728,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "256": [
+   "255": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -800,7 +796,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "264": [
+   "263": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -863,6 +859,11 @@ export const recordedHistory = {
    ],
    "271": [
       {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
          "type": "collisions",
          "collisions": {
             "enemiesThatWereHit": [
@@ -883,11 +884,6 @@ export const recordedHistory = {
       }
    ],
    "272": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -922,6 +918,11 @@ export const recordedHistory = {
    ],
    "279": [
       {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
          "type": "collisions",
          "collisions": {
             "enemiesThatWereHit": [
@@ -942,11 +943,6 @@ export const recordedHistory = {
       }
    ],
    "280": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -981,7 +977,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "288": [
+   "287": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1033,7 +1029,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "296": [
+   "295": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1094,7 +1090,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "304": [
+   "303": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1155,12 +1151,14 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "312": [
+   "311": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      },
+      }
+   ],
+   "312": [
       {
          "type": "collisions",
          "collisions": {
@@ -1214,9 +1212,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "320": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1268,7 +1264,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "328": [
+   "327": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1320,7 +1316,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "336": [
+   "335": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1381,7 +1377,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "344": [
+   "343": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1416,12 +1412,14 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "352": [
+   "351": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      },
+      }
+   ],
+   "352": [
       {
          "type": "collisions",
          "collisions": {
@@ -1475,9 +1473,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "360": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1534,7 +1530,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "368": [
+   "367": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1586,7 +1582,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "376": [
+   "375": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1621,7 +1617,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "384": [
+   "383": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1673,12 +1669,14 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "392": [
+   "391": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      },
+      }
+   ],
+   "392": [
       {
          "type": "collisions",
          "collisions": {
@@ -1732,9 +1730,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "400": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1791,7 +1787,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "408": [
+   "407": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1826,7 +1822,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "416": [
+   "415": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1878,7 +1874,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "424": [
+   "423": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1930,12 +1926,14 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "432": [
+   "431": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      },
+      }
+   ],
+   "432": [
       {
          "type": "collisions",
          "collisions": {
@@ -1989,37 +1987,6 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "440": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      }
-   ],
-   "448": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      }
-   ],
-   "456": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
       },
       {
          "type": "add_points",
@@ -2032,7 +1999,19 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "464": [
+   "447": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      }
+   ],
+   "455": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2049,7 +2028,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "472": [
+   "463": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2066,7 +2045,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "480": [
+   "471": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2083,7 +2062,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "488": [
+   "479": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2100,7 +2079,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "496": [
+   "487": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2117,7 +2096,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "504": [
+   "495": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2134,7 +2113,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "512": [
+   "503": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2151,7 +2130,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "520": [
+   "511": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2168,7 +2147,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "528": [
+   "519": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2185,7 +2164,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "536": [
+   "527": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2202,7 +2181,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "544": [
+   "535": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2219,7 +2198,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "552": [
+   "543": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2236,7 +2215,24 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "560": [
+   "551": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      }
+   ],
+   "559": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2281,7 +2277,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "568": [
+   "567": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2321,7 +2317,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "576": [
+   "575": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2361,7 +2357,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "584": [
+   "583": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2373,7 +2369,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "592": [
+   "591": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2390,7 +2386,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "600": [
+   "599": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2469,22 +2465,24 @@ export const recordedHistory = {
          "points": -0.2
       }
    ],
+   "607": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      }
+   ],
    "608": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -2670,7 +2668,7 @@ export const recordedHistory = {
          "points": -0.2
       }
    ],
-   "616": [
+   "615": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17133,7 +17131,7 @@ export const recordedHistory = {
          "points": -0.2
       }
    ],
-   "1394": [
+   "1393": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17150,7 +17148,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1402": [
+   "1401": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17167,7 +17165,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1410": [
+   "1409": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17184,7 +17182,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1418": [
+   "1417": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17201,7 +17199,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1426": [
+   "1425": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17218,7 +17216,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1436": [
+   "1435": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17235,7 +17233,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1444": [
+   "1443": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17252,7 +17250,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1451": [
+   "1450": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17269,7 +17267,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1459": [
+   "1458": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17314,7 +17312,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1467": [
+   "1466": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17354,7 +17352,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1475": [
+   "1474": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17394,7 +17392,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1483": [
+   "1482": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17434,7 +17432,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1491": [
+   "1490": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17476,6 +17474,16 @@ export const recordedHistory = {
    ],
    "1498": [
       {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
          "type": "collisions",
          "collisions": {
             "enemiesThatWereHit": [
@@ -17496,16 +17504,6 @@ export const recordedHistory = {
       }
    ],
    "1499": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17732,6 +17730,16 @@ export const recordedHistory = {
    "1506": [
       {
          "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
       },
@@ -17777,16 +17785,6 @@ export const recordedHistory = {
       }
    ],
    "1507": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "collisions",
          "collisions": {
@@ -17885,7 +17883,7 @@ export const recordedHistory = {
          "points": -0.2
       }
    ],
-   "1515": [
+   "1514": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -18216,7 +18214,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1531": [
+   "1530": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -18353,6 +18351,16 @@ export const recordedHistory = {
    "1538": [
       {
          "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
       },
@@ -18417,16 +18425,6 @@ export const recordedHistory = {
       }
    ],
    "1539": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -18624,6 +18622,16 @@ export const recordedHistory = {
    "1549": [
       {
          "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
       },
@@ -18683,16 +18691,6 @@ export const recordedHistory = {
       }
    ],
    "1550": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18891,6 +18889,16 @@ export const recordedHistory = {
    ],
    "1560": [
       {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
          "type": "collisions",
          "collisions": {
             "enemiesThatWereHit": [
@@ -18911,16 +18919,6 @@ export const recordedHistory = {
       }
    ],
    "1561": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -19331,19 +19329,19 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       }
    ],
    "1577": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -19408,7 +19406,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1590": [
+   "1589": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19443,17 +19441,19 @@ export const recordedHistory = {
          "points": -1
       }
    ],
+   "1599": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      }
+   ],
    "1600": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "collisions",
          "collisions": {
@@ -19481,7 +19481,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1608": [
+   "1607": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19493,7 +19493,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1616": [
+   "1615": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19505,7 +19505,24 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1624": [
+   "1623": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      }
+   ],
+   "1631": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19523,21 +19540,6 @@ export const recordedHistory = {
       }
    ],
    "1632": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "collisions",
          "collisions": {
@@ -19567,6 +19569,21 @@ export const recordedHistory = {
    ],
    "1639": [
       {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
          "type": "collisions",
          "collisions": {
             "enemiesThatWereHit": [
@@ -19587,21 +19604,6 @@ export const recordedHistory = {
       }
    ],
    "1640": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19634,9 +19636,7 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1648": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19649,6 +19649,16 @@ export const recordedHistory = {
       }
    ],
    "1655": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -19674,7 +19684,9 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      },
+      }
+   ],
+   "1663": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19686,7 +19698,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1664": [
+   "1671": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19698,19 +19710,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1672": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      }
-   ],
-   "1680": [
+   "1679": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19727,7 +19727,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1687": [
+   "1686": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19744,7 +19744,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1694": [
+   "1693": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19761,7 +19761,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1702": [
+   "1701": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19778,7 +19778,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1710": [
+   "1709": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19795,7 +19795,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1718": [
+   "1717": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19812,7 +19812,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1726": [
+   "1725": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19829,7 +19829,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1734": [
+   "1733": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19846,7 +19846,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1741": [
+   "1740": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19863,7 +19863,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1748": [
+   "1747": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19880,7 +19880,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1756": [
+   "1755": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19897,7 +19897,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1764": [
+   "1763": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19914,7 +19914,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1772": [
+   "1771": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19931,7 +19931,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1782": [
+   "1781": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19948,7 +19948,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1790": [
+   "1789": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19965,7 +19965,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1798": [
+   "1797": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19982,7 +19982,7 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1806": [
+   "1805": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19999,7 +19999,24 @@ export const recordedHistory = {
          "points": -1
       }
    ],
-   "1814": [
+   "1813": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
+      }
+   ],
+   "1823": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -20017,21 +20034,6 @@ export const recordedHistory = {
       }
    ],
    "1824": [
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -20217,7 +20219,7 @@ export const recordedHistory = {
          "points": -0.2
       }
    ],
-   "1832": [
+   "1831": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -20361,68 +20363,6 @@ export const recordedHistory = {
    "1839": [
       {
          "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
-      }
-   ],
-   "1840": [
-      {
-         "type": "add_points",
          "enemy": "playerShot",
          "points": -1
       },
@@ -20435,6 +20375,66 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       }
    ],
    "1842": [

--- a/src/App/services/E2eTest/e2ehistory.ts
+++ b/src/App/services/E2eTest/e2ehistory.ts
@@ -19,14 +19,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "132": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "132": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -45,7 +45,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "133": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -78,7 +80,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "139": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -116,14 +120,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "152": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "152": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -159,7 +163,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "159": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -209,7 +215,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "173": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -247,14 +255,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "179": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "179": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -273,7 +281,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "180": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -311,14 +321,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "186": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "186": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -337,7 +347,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "187": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -368,14 +380,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "193": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "193": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -394,7 +406,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "194": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -420,7 +434,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "199": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -453,7 +469,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "206": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -486,14 +504,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "213": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "213": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -512,7 +530,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "214": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -557,7 +577,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "226": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -583,14 +605,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "232": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "232": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -621,7 +643,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "239": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -659,7 +683,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "246": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -697,7 +723,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "254": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -735,7 +763,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "259": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -761,7 +791,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "261": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -794,14 +826,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "266": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "266": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -820,7 +852,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "267": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -846,14 +880,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "272": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "272": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -877,7 +911,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "273": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -903,14 +939,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "280": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "280": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -936,7 +972,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "286": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -974,11 +1012,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -986,6 +1019,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "293": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1019,14 +1059,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "299": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "299": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -1045,7 +1085,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "300": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1078,14 +1120,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "306": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "306": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -1104,7 +1146,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "307": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1135,7 +1179,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "313": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1161,7 +1207,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "319": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1199,11 +1247,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1211,6 +1254,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "326": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1249,11 +1299,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1261,6 +1306,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "333": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1294,14 +1346,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "339": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "339": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -1320,7 +1372,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "340": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1353,7 +1407,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "346": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1384,7 +1440,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "353": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1410,7 +1468,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "359": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1453,11 +1513,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1465,6 +1520,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "366": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1503,11 +1565,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1515,6 +1572,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "373": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1548,7 +1612,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "379": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1586,11 +1652,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1598,6 +1659,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "386": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1629,7 +1697,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "393": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1655,7 +1725,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "399": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1698,11 +1770,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1710,6 +1777,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "406": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1743,7 +1817,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "413": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1781,11 +1857,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1793,6 +1864,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "419": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1831,11 +1909,6 @@ export const recordedHistory = {
       },
       {
          "type": "add_points",
-         "enemy": "playerShot",
-         "points": -1
-      },
-      {
-         "type": "add_points",
          "points": 10,
          "enemy": "nonShootingAimer"
       },
@@ -1843,6 +1916,13 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
+      }
+   ],
+   "426": [
+      {
+         "type": "add_points",
+         "enemy": "playerShot",
+         "points": -1
       },
       {
          "type": "add_points",
@@ -1874,7 +1954,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "433": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -1900,7 +1982,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "439": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2188,7 +2272,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "565": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2226,7 +2312,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "572": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -2264,7 +2352,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "578": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -4040,7 +4130,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "684": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -4066,14 +4158,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "686": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "686": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -4142,7 +4234,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "687": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -5078,14 +5172,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "784": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "784": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -5104,7 +5198,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "785": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -5130,14 +5226,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "787": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "787": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -5806,7 +5902,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "818": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -5832,14 +5930,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "820": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "820": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -5908,7 +6006,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "821": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -8270,14 +8370,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "937": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "937": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -8356,7 +8456,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "938": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -8382,14 +8484,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "940": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "940": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -9306,7 +9408,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "983": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -9332,14 +9436,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "985": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "985": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -9408,7 +9512,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "986": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -10466,7 +10572,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1037": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -10492,14 +10600,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1039": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1039": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -10568,7 +10676,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1040": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -11750,7 +11860,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1097": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -11776,14 +11888,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1099": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1099": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -11852,7 +11964,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1100": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -13406,7 +13520,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1175": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -13432,14 +13548,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1177": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1177": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -13508,7 +13624,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1178": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -15498,14 +15616,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1276": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1276": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -15584,7 +15702,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1277": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -15610,14 +15730,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1279": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1279": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17185,7 +17305,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1465": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17223,7 +17345,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1472": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17261,7 +17385,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1480": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17299,7 +17425,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1487": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17337,7 +17465,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1495": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -17363,11 +17493,6 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
       }
    ],
    "1499": [
@@ -17380,6 +17505,11 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       },
       {
          "type": "collisions",
@@ -17399,14 +17529,19 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
+      }
+   ],
+   "1500": [
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       },
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1500": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17462,14 +17597,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1502": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1502": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17488,14 +17623,19 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
+      }
+   ],
+   "1503": [
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       },
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1503": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17561,14 +17701,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1505": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1505": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17587,14 +17727,19 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
+      }
+   ],
+   "1506": [
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       },
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1506": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17660,14 +17805,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1508": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1508": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17686,14 +17831,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1509": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1509": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17771,14 +17916,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1520": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1520": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17797,14 +17942,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1521": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1521": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17823,14 +17968,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1522": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1522": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17884,14 +18029,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1523": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1523": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17910,7 +18055,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1524": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -17971,14 +18118,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1526": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1526": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -17997,7 +18144,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1527": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18058,7 +18207,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1529": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -18096,14 +18247,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1533": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1533": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18122,7 +18273,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1534": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18188,7 +18341,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1536": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18259,14 +18414,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1539": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1539": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -18297,14 +18452,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1543": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1543": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18323,7 +18478,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1544": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18349,14 +18506,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1546": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1546": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18410,14 +18567,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1547": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1547": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18436,14 +18593,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1548": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1548": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18462,14 +18619,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1549": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1549": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18523,11 +18680,6 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
       }
    ],
    "1550": [
@@ -18540,6 +18692,11 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       }
    ],
    "1551": [
@@ -18561,14 +18718,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1552": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1552": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18627,7 +18784,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1553": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18695,14 +18854,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1558": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1558": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18721,7 +18880,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1559": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18747,11 +18908,6 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
-      {
-         "type": "add_points",
-         "enemy": "playerLaser",
-         "points": -0.2
       }
    ],
    "1561": [
@@ -18764,6 +18920,11 @@ export const recordedHistory = {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
       },
       {
          "type": "collisions",
@@ -18783,14 +18944,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1562": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1562": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18844,14 +19005,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1563": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1563": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18870,14 +19031,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1564": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1564": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -18896,14 +19057,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1565": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1565": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -18996,14 +19157,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1570": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1570": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -19022,7 +19183,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1571": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -19048,14 +19211,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1573": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1573": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -19074,14 +19237,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1574": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1574": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -19135,14 +19298,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1575": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1575": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -19161,7 +19324,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1576": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19234,7 +19399,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1584": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19267,7 +19434,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1593": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19303,7 +19472,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1601": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19385,7 +19556,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1633": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19411,14 +19584,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1640": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1640": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19454,7 +19627,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1647": [
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -19492,14 +19667,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerShot"
-      },
+      }
+   ],
+   "1656": [
       {
          "type": "add_points",
          "enemy": "playerShot",
          "points": -1
-      }
-   ],
-   "1656": [
+      },
       {
          "type": "add_points",
          "enemy": "playerShot",
@@ -21335,7 +21510,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1892": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -21413,7 +21590,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1895": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -21491,7 +21670,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1898": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -21564,7 +21745,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1901": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -21635,14 +21818,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1903": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1903": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -21661,7 +21844,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1904": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -21722,14 +21907,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1906": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1906": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -21748,7 +21933,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1907": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -22487,14 +22674,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1950": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1950": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -22565,14 +22752,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1952": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1952": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -22591,14 +22778,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1953": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1953": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -22664,14 +22851,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1955": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1955": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -22690,14 +22877,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1956": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1956": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -22753,14 +22940,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1958": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1958": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -22779,14 +22966,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1959": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1959": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -22842,14 +23029,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1961": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1961": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -22868,14 +23055,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1962": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1962": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -22931,14 +23118,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1964": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1964": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -22957,14 +23144,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1965": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1965": [
+      },
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23025,7 +23212,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1967": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23093,7 +23282,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1970": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23166,7 +23357,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1973": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23237,14 +23430,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1975": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1975": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -23263,7 +23456,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1976": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23334,14 +23529,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1978": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1978": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -23360,7 +23555,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1979": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23421,14 +23618,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1981": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1981": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -23447,7 +23644,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1982": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23508,14 +23707,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1984": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1984": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -23534,7 +23733,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1985": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23595,14 +23796,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1987": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "1987": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -23621,7 +23822,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1988": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23684,7 +23887,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1991": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23747,7 +23952,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1994": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23820,7 +24027,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "1997": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23893,7 +24102,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2000": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -23966,7 +24177,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2003": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -24039,7 +24252,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2006": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -24112,7 +24327,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2009": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -24185,7 +24402,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2012": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -24258,7 +24477,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2015": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -25517,7 +25738,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2087": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -25593,14 +25816,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2089": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "2089": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -25619,7 +25842,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2090": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -25690,14 +25915,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2092": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "2092": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -25716,7 +25941,9 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2093": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
@@ -25777,14 +26004,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2095": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "2095": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -25803,14 +26030,14 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "playerLaser"
-      },
+      }
+   ],
+   "2096": [
       {
          "type": "add_points",
          "enemy": "playerLaser",
          "points": -0.2
-      }
-   ],
-   "2096": [
+      },
       {
          "type": "collisions",
          "collisions": {
@@ -25823,9 +26050,73 @@ export const recordedHistory = {
          "type": "add_points",
          "points": 0,
          "enemy": "player"
-      },
+      }
+   ],
+   "2097": [
       {
          "type": "gameOver"
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "add_points",
+         "enemy": "playerLaser",
+         "points": -0.2
+      },
+      {
+         "type": "collisions",
+         "collisions": {
+            "enemiesThatWereHit": [
+               "player-0"
+            ]
+         }
+      },
+      {
+         "type": "collisions",
+         "collisions": {
+            "enemiesThatWereHit": [
+               "firstMiniboss-1",
+               "playerLaser-2047"
+            ]
+         }
+      },
+      {
+         "type": "add_points",
+         "points": 10,
+         "enemy": "firstMiniboss"
+      },
+      {
+         "type": "add_points",
+         "points": 0,
+         "enemy": "playerLaser"
       }
    ]
 };

--- a/src/App/services/E2eTest/e2ehistory.ts
+++ b/src/App/services/E2eTest/e2ehistory.ts
@@ -25825,7 +25825,7 @@ export const recordedHistory = {
          "enemy": "player"
       },
       {
-         "type": "player_died"
+         "type": "gameOver"
       }
    ]
 };

--- a/src/App/services/E2eTest/variants/E2eRecordEvents.ts
+++ b/src/App/services/E2eTest/variants/E2eRecordEvents.ts
@@ -48,7 +48,7 @@ export class E2eRecordEvents implements IE2eTest {
    };
 
    private onEvent = (event: TGameEvent | TPointsEvent | TCollisionsEvent) => {
-      if (event.type === "player_died") {
+      if (event.type === "gameOver") {
          console.log("E2eRecordEvents.history:");
          console.log(this.history);
       }

--- a/src/App/services/Enemies/Enemies.ts
+++ b/src/App/services/Enemies/Enemies.ts
@@ -83,27 +83,11 @@ export class Enemies implements IService {
       /**
        * prepend the actions that the parent sent. this allow parent some control over it's spawn.
        * also add die-when-outside-screen behaviour too all spawns.
-       * TODO:
-       * This is elegant. Maybe add the die-when-outside-screen behaviour in some other way
        */
       const newEnemyJson: IEnemyJson = {
          ...enemyJson,
          actions: [
-            // Set some default attributes. TODO: Should prolly do this in another way.
-            { type: AT.setAttribute, attribute: "points", value: 10 },
-            { type: AT.setAttribute, attribute: "pointsOnDeath", value: 0 },
-            { type: AT.setAttribute, attribute: "collisionType", value: "enemy" },
-            { type: AT.setAttribute, attribute: "boundToWindow", value: false },
             ...parentIdAction,
-            {
-               type: AT.fork,
-               actions: [
-                  // TODO: Comment
-                  { type: AT.waitTilInsideScreen },
-                  { type: AT.waitTilOutsideScreen },
-                  { type: AT.despawn }
-               ]
-            },
             ...prependActions,
             ...enemyJson.actions
          ]

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -47,9 +47,6 @@ export class Enemy {
          input: this.enemies.input,
          gamepad: this.enemies.gamepad,
       });
-      // TODO: Attrs should be be set by an Action in future, right?
-      this.hp = json.hp;
-      this.maxHp = json.hp;
 
       this.graphics = this.enemies.graphics;
       this.gfx = new EnemyGfx({
@@ -63,12 +60,6 @@ export class Enemy {
    }
    private set hp(value: number){
       this.attrs.setAttribute({ gameObjectId: this.id, attribute: "hp", value });
-   }
-   private get maxHp(): number {
-      return assertNumber(this.attrs.getAttribute({ gameObjectId: this.id, attribute: "maxHp" }));
-   }
-   private set maxHp(value: number){
-      this.attrs.setAttribute({ gameObjectId: this.id, attribute: "maxHp", value });
    }
 
    public get Radius(){ return this.diameter/2; }

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -142,7 +142,7 @@ export class Enemy {
       }
 
       if(this === this.enemies.player && !this.enemies.settings.settings.invincibility) {
-         this.enemies.events.dispatchEvent({ type: "player_died" });
+         this.enemies.events.dispatchEvent({ type: "gameOver" });
       }
    };
 
@@ -229,7 +229,7 @@ export class Enemy {
             break;
          }
          case AT.finishLevel: // TODO: dispatch some new "finishLevel" event instead.
-            this.enemies.events.dispatchEvent({ type: "player_died" }); 
+            this.enemies.events.dispatchEvent({ type: "gameOver" }); 
             break;
          default:
             this.gfx?.dispatch(action as TGraphicsActionWithoutHandle);

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -13,7 +13,6 @@ import { uuid } from "../../../utils/uuid";
 import { resolutionHeight, resolutionWidth } from "../../../consts";
 import { assertNumber } from "../../../utils/typeAssertions";
 import { EnemyGfx } from "./EnemyGfx";
-import { BrowserDriver } from "../../../drivers/BrowserDriver";
 
 export class Enemy {
    public X: number;
@@ -33,8 +32,6 @@ export class Enemy {
    private actionExecutor: EnemyActionExecutor;
    private gfx?: EnemyGfx; // handle to GraphicsElement from Graphics service.
    private name: string;
-   // One action that is executed immediately when an enemy dies.
-   private onDeathAction?: TAction;
 
    public constructor( enemies: Enemies, position: TVector, json: IEnemyJson ) {
       this.enemies = enemies;
@@ -50,7 +47,6 @@ export class Enemy {
          input: this.enemies.input,
          gamepad: this.enemies.gamepad,
       });
-      this.onDeathAction = json.onDeathAction;
       // TODO: Attrs should be be set by an Action in future, right?
       this.hp = json.hp;
       this.maxHp = json.hp;
@@ -103,8 +99,6 @@ export class Enemy {
       // TODO: add_points is a bad name. Should be names pointsOnHit.
       this.enemies.eventsPoints.dispatchEvent({ type: "add_points", points, enemy: this.name });
       this.hp -= 1;
-
-      if(this.hp < 1) { this.die(); }
    };
 
    private boundToWindow = () => {
@@ -140,27 +134,6 @@ export class Enemy {
          this.gfx.release();
          this.gfx = undefined;
       }
-
-      if(this === this.enemies.player && !this.enemies.settings.settings.invincibility) {
-         this.enemies.events.dispatchEvent({ type: "gameOver" });
-      }
-   };
-
-   // unlike despawn die triggers onDeathAction
-   private die = () => {
-      if(this === this.enemies.player && this.enemies.settings.settings.invincibility) {
-         return; // Don't kill player if invincible. TODO: Mayb this should b in OnCollision instead
-      }
-      if(this.onDeathAction) {
-         const done = this.actionExecutor.ExecuteOneAction(this.onDeathAction);
-         if(!done) {
-            BrowserDriver.Alert(
-               `Enemy '${this.id}'s onDeathAction required more than 1 frame to execute.
-               An onDeathAction must be able to finish execution after 1 frame.`
-            );
-         }
-      }
-      this.despawn();
    };
 
    /**
@@ -214,9 +187,6 @@ export class Enemy {
             break;
          case AT.despawn:
             this.despawn();
-            break;
-         case AT.die:
-            this.die();
             break;
          case AT.incr: { // this I believe could be move into EnemyActionExecutor??
             const { gameObjectId, attribute } = action;

--- a/src/App/services/Enemies/Enemy.ts
+++ b/src/App/services/Enemies/Enemy.ts
@@ -230,6 +230,10 @@ export class Enemy {
       });
    };
 
+   /**
+    * TODO: This should be removed. Instead I should do this somehow with an action or attributes,
+    * so that you can shoot toward any position (or any position of a GameObject).
+    */
    private ShootTowardPlayer = () => {
       const player = this.enemies.player;
       const dirX = player.X - this.X;

--- a/src/App/services/Enemies/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/EnemyActionExecutor.ts
@@ -77,7 +77,6 @@ export class EnemyActionExecutor {
           * During the execution more generators can be added,
           * so only if the number has not been changed can we make assumptions about all generators
           * having finished or not.
-          * 
           * But... couldn't one generator be added and another one deleted, +1 -1 = 0 ??
           */
          const allDone = nexts.every(next => next.done);
@@ -129,10 +128,6 @@ export class EnemyActionExecutor {
 
       while(currIndex < nrActions) { // if index 1 & nr 2 => kosher
          const currAction = actions[currIndex];
-         // if (this.enemy.id.includes("spin") || this.enemy.id.includes("stage")) {
-         //    console.log(`${this.enemy.id} will execute ${currAction.type}`);
-         // }
-         // console.log(currAction.type);
          switch(currAction.type) {
             case AT.moveAccordingToInput: {
                const input = this.input;
@@ -328,14 +323,15 @@ export class EnemyActionExecutor {
                yield* rotateAroundPoint(currAction, pointToPosVector, this.actionHandler);
                break;
             }
+            
+            case AT.log:
+               console.log(`LogAction: ${currAction.msg}`);
+               break;
 
             default:
                this.actionHandler(currAction);
          }
          currIndex++;
-         // if (this.enemy.id.includes("spin") || this.enemy.id.includes("stage")) {
-         //    console.log(`${this.enemy.id} executed ${currAction.type}`);
-         // }
       }
    }
 }

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -32,7 +32,6 @@ export enum ActionType {
    mirrorX = "mirrorX",
    mirrorY = "mirrorY",
    do = "do",
-   die = "die",
    despawn = "despawn",
    waitTilOutsideScreen = "waitTilOutsideScreen",
    waitTilInsideScreen = "waitTilInsideScreen",
@@ -69,6 +68,11 @@ export enum ActionType {
     */
    gfxAskForElement = "gfxAskForElement",
    gfxRelease = "gfxRelease",
+
+   /**
+    * Log
+    */
+   log = "log",
 }
 
 /**
@@ -156,12 +160,9 @@ export type TMirrorY = { type: ActionType.mirrorY, value: boolean };
  * The action simple executes the actions sent to it. As simple as that.
  */
 export type TDo = { type: ActionType.do, acns: TAction[] };
-// Well, the enemy dies.
-export type TDie = { type: ActionType.die };
 /**
- * Enemy despawns. Like "die" except onDeathAction is NOT triggered.
+ * Enemy despawns.
  * An example of when this should be used is when an enemy despawns outside of the screen,
- * you probably don't want to trigger an onDeath with explodes the enemy into bullets.
  */
 export type TDespawn = { type: ActionType.despawn };
 /**
@@ -203,6 +204,9 @@ export type TWaitInputLaser = Readonly<{ type: ActionType.waitInputLaser }>;
 
 // Signals that the level has been finished, so trigger this when end boss dies or something similar
 export type TFinishLevel = Readonly<{ type: ActionType.finishLevel }>;
+
+// Action to console.log, so you can debug actions.
+export type TLog = Readonly<{ type: ActionType.log, msg: string }>;
 
 export type TAction = Readonly<
    /**
@@ -246,7 +250,6 @@ export type TAction = Readonly<
    * Spawning/Life cycle
    */
    TSpawn |
-   TDie |
    TDespawn |
    TWaitTilOutsideScreen |
    TWaitTilInsideScreen |
@@ -268,5 +271,9 @@ export type TAction = Readonly<
     * And also all Graphics actions
     * I remove the handles because the enemy that executes the actions has the handle already.
     */
-   TGraphicsActionWithoutHandle
+   TGraphicsActionWithoutHandle |
+   /**
+    * Log
+    */
+   TLog
 >;

--- a/src/App/services/Events/IEvents.ts
+++ b/src/App/services/Events/IEvents.ts
@@ -28,7 +28,7 @@ type TEventFrameTick = { type: "frame_tick", frameNr: number };
 
 export type TGameEvent =
    TEventFrameTick | // signals next frame has come.
-   { type: "player_died" }; // when player dies.
+   { type: "gameOver" }; // when player dies.
 
 export type TGameEventCallback =  TEventCallback<TGameEvent>;
 export type TGameEventSubscribers = TEventSubscribers<TGameEvent>

--- a/src/App/services/Input/Input.ts
+++ b/src/App/services/Input/Input.ts
@@ -58,7 +58,7 @@ export class Input implements IInput {
             case "frame_tick":
                this.frameCount = event.frameNr;
                break;
-            case "player_died":
+            case "gameOver":
                console.log("Input.history:");
                console.log(this.history);
                break;

--- a/src/App/services/Points/Points.ts
+++ b/src/App/services/Points/Points.ts
@@ -36,7 +36,7 @@ export class Points implements IPoints {
             this.updatePoints();
             break;
          }
-         case "player_died":
+         case "gameOver":
             // unsub because we dont want to get in here again.
             this.app.events.unsubscribeToEvent(this.name);
             break;

--- a/src/App/services/UI/UI.ts
+++ b/src/App/services/UI/UI.ts
@@ -103,7 +103,7 @@ export class UI implements IUI {
 
    private onEvent = (event: TGameEvent) => {
       switch(event.type) {
-         case "player_died": {
+         case "gameOver": {
             this.gameLoop.pause();
             this.SetActiveScene(this.gameOver);
             break;

--- a/src/gameData/game1/effects/explosions.ts
+++ b/src/gameData/game1/effects/explosions.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { wait } from "../../utils";
+import { createGameObject, wait } from "../../utils";
 
-export const explosion: IEnemyJson = {
+export const explosion: IEnemyJson = createGameObject({
    name: "explosion",
    diameter: 18,
    hp: 9999,
@@ -14,9 +14,9 @@ export const explosion: IEnemyJson = {
       // { type: "wait", frames: 40 },
       { type: AT.despawn },
    ],
-};
+});
 
-export const roundExplosion: IEnemyJson = {
+export const roundExplosion: IEnemyJson = createGameObject({
    name: "roundExplosion",
    diameter: 40,
    hp: 9999,
@@ -27,4 +27,4 @@ export const roundExplosion: IEnemyJson = {
       // { type: "wait", frames: 75 },
       { type: AT.despawn },
    ],
-};
+});

--- a/src/gameData/game1/parallax/parallax.ts
+++ b/src/gameData/game1/parallax/parallax.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
-import { forever, spawn, wait } from "@/gameData/utils";
+import { createGameObject, forever, spawn, wait } from "@/gameData/utils";
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const parallax: IEnemyJson = {
+export const parallax: IEnemyJson = createGameObject({
    name: "parallax",
    diameter: 240,
    hp: 9999,
@@ -16,9 +16,9 @@ export const parallax: IEnemyJson = {
       spawn("layer2"),
       spawn("layer3"),
    ],
-};
+});
 
-export const layer1: IEnemyJson = {
+export const layer1: IEnemyJson = createGameObject({
    name: "layer1",
    diameter: 240,
    hp: 9999,
@@ -31,9 +31,9 @@ export const layer1: IEnemyJson = {
          { type: AT.gfxScrollBg, y: -0.3 }
       )
    ],
-};
+});
 
-export const layer2: IEnemyJson = {
+export const layer2: IEnemyJson = createGameObject({
    name: "layer2",
    diameter: 240,
    hp: 9999,
@@ -46,9 +46,9 @@ export const layer2: IEnemyJson = {
          { type: AT.gfxScrollBg, y: -1 }
       )
    ],
-};
+});
 
-export const layer3: IEnemyJson = {
+export const layer3: IEnemyJson = createGameObject({
    name: "layer3",
    diameter: 240,
    hp: 9999,
@@ -61,4 +61,4 @@ export const layer3: IEnemyJson = {
          { type: AT.gfxScrollBg, y: -1.5 }
       )
    ],
-};
+});

--- a/src/gameData/game1/player/player.ts
+++ b/src/gameData/game1/player/player.ts
@@ -1,8 +1,7 @@
-import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "../../../App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
-import { forever, fork, wait } from "../../utils";
+import { createGameObject, forever, fork, wait } from "../../utils";
 
 type TCreateShotArgs = { moveDeltaX: number, moveDeltaY: number };
 
@@ -33,10 +32,11 @@ const laser: TAction[] = [
    wait(3),
 ];
 
-export const player: IEnemyJson = {
+export const player = createGameObject({
    name: "player",
    diameter: 20,
    hp: 1,
+   onDeathAction: { type: AT.finishLevel }, // TODO: finishLevel should maybe be called gameOver.
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
@@ -66,4 +66,4 @@ export const player: IEnemyJson = {
          ...laser
       )),
    ]
-};
+});

--- a/src/gameData/game1/player/playerLaser.ts
+++ b/src/gameData/game1/player/playerLaser.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { forever, parallelRace, spawn, wait } from "../../utils";
+import { createGameObject, forever, parallelRace, spawn, wait } from "../../utils";
 
-export const playerLaser: IEnemyJson = {
+export const playerLaser: IEnemyJson = createGameObject({
    name: "playerLaser",
    hp: 1,
    diameter: 5,
@@ -26,4 +26,4 @@ export const playerLaser: IEnemyJson = {
          ]
       )
    ]
-};
+});

--- a/src/gameData/game1/player/playerShot.ts
+++ b/src/gameData/game1/player/playerShot.ts
@@ -1,10 +1,10 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
-import { spawn } from "../../utils";
+import { createGameObject, spawn } from "../../utils";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const playerShot: IEnemyJson = {
+export const playerShot: IEnemyJson = createGameObject({
    name: "playerShot",
    hp: 1,
    diameter: 5,
@@ -17,4 +17,4 @@ export const playerShot: IEnemyJson = {
       { type: AT.gfxSetShape, shape: "circle" },
       { type: AT.gfxSetColor, color: "aqua" },
    ],
-};
+});

--- a/src/gameData/game1/shot.ts
+++ b/src/gameData/game1/shot.ts
@@ -1,8 +1,9 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+import { createGameObject } from "../utils";
 
-export const shot: IEnemyJson = {
+export const shot: IEnemyJson = createGameObject({
    name: "shot",
    hp: 9999,
    diameter: 5,
@@ -11,4 +12,4 @@ export const shot: IEnemyJson = {
       { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: AT.gfxSetShape, shape: "circle" }
    ]
-};
+});

--- a/src/gameData/game1/shot.ts
+++ b/src/gameData/game1/shot.ts
@@ -1,12 +1,13 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { createGameObject } from "../utils";
+import { createGameObject, spawn } from "../utils";
 
 export const shot: IEnemyJson = createGameObject({
    name: "shot",
    hp: 1,
    diameter: 5,
+   onDeathAction: spawn("explosion"),
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },
       { type: AT.setAttribute, attribute: "points", value: 0 },

--- a/src/gameData/game1/shot.ts
+++ b/src/gameData/game1/shot.ts
@@ -5,7 +5,7 @@ import { createGameObject } from "../utils";
 
 export const shot: IEnemyJson = createGameObject({
    name: "shot",
-   hp: 9999,
+   hp: 1,
    diameter: 5,
    actions: [
       { type: AT.setAttribute, attribute: "collisionType", value: "enemyBullet" },

--- a/src/gameData/game1/spawner.ts
+++ b/src/gameData/game1/spawner.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { fork, spawn, wait } from "../utils";
+import { createGameObject, fork, spawn, wait } from "../utils";
 
-export const spawner: IEnemyJson = {
+export const spawner: IEnemyJson = createGameObject({
    name: "spawner",
    diameter: 20,
    hp: 9999,
@@ -23,4 +23,4 @@ export const spawner: IEnemyJson = {
       // { type: "spawn", enemy: "stage4" },
       // spawn("stage5"),
    ],
-};
+});

--- a/src/gameData/game1/stage1.ts
+++ b/src/gameData/game1/stage1.ts
@@ -8,7 +8,7 @@ import type {
 
 import { ActionType as AT } from "../../App/services/Enemies/actions/actionTypes";
 import {
-   attr, forever, moveToAbsolute, parallelAll, parallelRace,
+   attr, createGameObject, forever, moveToAbsolute, parallelAll, parallelRace,
    repeat, setShotSpeed, setSpeed, spawn, thrice, twice, wait
 } from "../utils";
 
@@ -42,7 +42,7 @@ const sinuses = repeat(5, [
    wait(70),
 ]);
 
-export const stage1: IEnemyJson = {
+export const stage1: IEnemyJson = createGameObject({
    name: "stage1",
    diameter: 20,
    hp: 9999,
@@ -57,11 +57,11 @@ export const stage1: IEnemyJson = {
       leftMiniBoss,
       rightMiniBoss,
    ]
-};
+});
 
 //------------------------------------------------------------
 
-export const nonShootingAimer: IEnemyJson = {
+export const nonShootingAimer: IEnemyJson = createGameObject({
    name: "nonShootingAimer",
    hp: 4,
    diameter: 22,
@@ -79,7 +79,7 @@ export const nonShootingAimer: IEnemyJson = {
          )
       )
    ]
-};
+});
 
 //------------------------------------------------------------
 
@@ -109,7 +109,7 @@ const rotateRightAndShoot = parallelAll(
    shootWhileRotation
 );
 
-export const sinus: IEnemyJson = {
+export const sinus: IEnemyJson = createGameObject({
    name: "sinus",
    hp: 3,
    diameter: 24,
@@ -124,7 +124,7 @@ export const sinus: IEnemyJson = {
          moveLeft
       )
    ]
-};
+});
 
 //------------------------------------------------------------
 
@@ -187,7 +187,7 @@ const movementPattern: TAction[] = [
    downOutOfScreen
 ];
 
-export const firstMiniboss: IEnemyJson = {
+export const firstMiniboss: IEnemyJson = createGameObject({
    name: "firstMiniboss",
    hp: 120,
    diameter: 35,
@@ -197,4 +197,4 @@ export const firstMiniboss: IEnemyJson = {
          movementPattern
       )
    ]
-};
+});

--- a/src/gameData/game1/stage2.ts
+++ b/src/gameData/game1/stage2.ts
@@ -2,10 +2,12 @@ import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { attr, forever, moveToAbsolute, parallelAll, setShotSpeed, wait } from "../utils";
+import {
+   attr, createGameObject, forever, moveToAbsolute, parallelAll, setShotSpeed, wait
+} from "../utils";
 import { col } from "./common";
 
-export const stage2: IEnemyJson = {
+export const stage2: IEnemyJson = createGameObject({
    name: "stage2",
    diameter: 20,
    hp: 9999,
@@ -15,9 +17,9 @@ export const stage2: IEnemyJson = {
       { type: AT.spawn, enemy: "cloner", x: col[2], y: -20 },
       { type: AT.spawn, enemy: "cloner", x: col[8], y: -20 },
    ]
-};
+});
 
-export const cloner: IEnemyJson = {
+export const cloner: IEnemyJson = createGameObject({
    name: "cloner",
    hp: 25,
    diameter: 29,
@@ -37,9 +39,9 @@ export const cloner: IEnemyJson = {
          { type: AT.setAttribute, attribute: "mirrorY", value: true }
       ]},
    ]
-};
+});
 
-export const clonerChild: IEnemyJson = {
+export const clonerChild: IEnemyJson = createGameObject({
    name: "clonerChild",
    hp: 10,
    diameter: 18,
@@ -58,4 +60,4 @@ export const clonerChild: IEnemyJson = {
          ],
       )
    ]
-};
+});

--- a/src/gameData/game1/stage3.ts
+++ b/src/gameData/game1/stage3.ts
@@ -1,10 +1,10 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { attr, forever, wait } from "../utils";
+import { attr, createGameObject, forever, wait } from "../utils";
 import { col, row } from "./common";
 
-export const stage3: IEnemyJson = {
+export const stage3: IEnemyJson = createGameObject({
    name: "stage3",
    diameter: 20,
    hp: 9999,
@@ -14,9 +14,9 @@ export const stage3: IEnemyJson = {
       { type: AT.spawn, enemy: "healer", x: col[4], y: row[4] },
       { type: AT.spawn, enemy: "dehealer", x: col[6], y: row[4] },
    ]
-};
+});
 
-export const shapeShifter: IEnemyJson = {
+export const shapeShifter: IEnemyJson = createGameObject({
    name: "shapeShifter",
    diameter: 30,
    hp: 100,
@@ -35,9 +35,9 @@ export const shapeShifter: IEnemyJson = {
          wait(60),
       )
    ]
-};
+});
 
-export const healer: IEnemyJson = {
+export const healer: IEnemyJson = createGameObject({
    name: "healer",
    diameter: 30,
    hp: 50,
@@ -51,9 +51,9 @@ export const healer: IEnemyJson = {
          })
       )
    ]
-};
+});
 
-export const dehealer: IEnemyJson = {
+export const dehealer: IEnemyJson = createGameObject({
    name: "dehealer",
    diameter: 30,
    hp: 50,
@@ -63,4 +63,4 @@ export const dehealer: IEnemyJson = {
          { type: AT.decr, attribute: "hp" }
       )
    ]
-};
+});

--- a/src/gameData/game1/stage4.ts
+++ b/src/gameData/game1/stage4.ts
@@ -2,7 +2,7 @@ import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 import type { TAction } from "../../App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "../../App/services/Enemies/actions/actionTypes";
-import { forever } from "../utils";
+import { createGameObject, forever } from "../utils";
 import { col, row } from "./common";
 
 const makeEasyFlyer = ({ x = col[1], y = -30}: { x?: number, y?: number}): TAction => ({
@@ -92,7 +92,7 @@ const wave4: TAction[] = [
    ]},
 ];
 
-export const stage4: IEnemyJson = {
+export const stage4: IEnemyJson = createGameObject({
    name: "stage4",
    diameter: 20,
    hp: 9999,
@@ -105,9 +105,9 @@ export const stage4: IEnemyJson = {
       { type: AT.wait, frames: 240 },
       ...wave4,
    ],
-};
+});
 
-export const easyFlyer: IEnemyJson = {
+export const easyFlyer: IEnemyJson = createGameObject({
    name: "easyFlyer",
    diameter: 29,
    hp: 5,
@@ -119,4 +119,4 @@ export const easyFlyer: IEnemyJson = {
          { type: AT.waitNextFrame },
       )
    ],
-};
+});

--- a/src/gameData/game1/stage5.ts
+++ b/src/gameData/game1/stage5.ts
@@ -1,10 +1,10 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { forever, repeat, spawn, wait } from "../utils";
+import { createGameObject, forever, repeat, spawn, wait } from "../utils";
 import { col, row } from "./common";
 
-export const stage5: IEnemyJson = {
+export const stage5: IEnemyJson = createGameObject({
    name: "stage5",
    diameter: 20,
    hp: 9999,
@@ -16,10 +16,10 @@ export const stage5: IEnemyJson = {
       spawn("repeatFromHp", { x: col[4], y: row[5] }),
       spawn("parent", { x: col[7], y: row[5] }),
    ],
-};
+});
 
 // Proves that attribute getter work with wait action.
-export const shotSpeedFromHp: IEnemyJson = {
+export const shotSpeedFromHp: IEnemyJson = createGameObject({
    name: "shotSpeedFromHp",
    diameter: 20,
    hp: 50,
@@ -32,10 +32,10 @@ export const shotSpeedFromHp: IEnemyJson = {
          { type: AT.shootDirection, x: 0, y: -1 },
       )
    ],
-};
+});
 
 // Proves that attribute getter work with repeat action.
-export const repeatFromHp: IEnemyJson = {
+export const repeatFromHp: IEnemyJson = createGameObject({
    name: "repeatFromHp",
    diameter: 20,
    hp: 50,
@@ -50,9 +50,9 @@ export const repeatFromHp: IEnemyJson = {
          { type: AT.shootDirection, x: 0, y: -1 },
       )
    ],
-};
+});
 
-export const executor: IEnemyJson = {
+export const executor: IEnemyJson = createGameObject({
    name: "executor",
    diameter: 30,
    hp: 100_000,
@@ -65,9 +65,9 @@ export const executor: IEnemyJson = {
          wait(35),
       )
    ],
-};
+});
 
-export const aqua: IEnemyJson = {
+export const aqua: IEnemyJson = createGameObject({
    name: "aqua",
    diameter: 30,
    hp: 100_000,
@@ -80,23 +80,23 @@ export const aqua: IEnemyJson = {
          wait(1),
       )
    ],
-};
+});
 
 /**
  * Proves that children have parents (parentId is stored in attribute "parentId" on the child).
  * Shooting on 
  */
-export const child: IEnemyJson = {
+export const child: IEnemyJson = createGameObject({
    name: "child",
    diameter: 20,
    hp: 100_000,
    actions: [
       { type: AT.gfxSetColor, color: "aqua" },
       { type: AT.waitUntilAttrIs, gameObjectId: { attr: "parentId" }, attr: "hp", is: 0 },
-      { type: AT.die },
+      { type: AT.setAttribute, attribute: "hp", value: 0 },
    ],
-};
-export const parent: IEnemyJson = {
+});
+export const parent: IEnemyJson = createGameObject({
    name: "parent",
    diameter: 25,
    hp: 5,
@@ -106,4 +106,4 @@ export const parent: IEnemyJson = {
       spawn("child", { x: 0,     y: -30 }),
       spawn("child", { x: 30,    y: -30 }),
    ],
-};
+});

--- a/src/gameData/game2/effects/explosions.ts
+++ b/src/gameData/game2/effects/explosions.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { wait } from "../../utils";
+import { createGameObject, wait } from "../../utils";
 
-export const explosion: IEnemyJson = {
+export const explosion: IEnemyJson = createGameObject({
    name: "explosion",
    diameter: 18,
    hp: 9999,
@@ -14,9 +14,9 @@ export const explosion: IEnemyJson = {
       // { type: "wait", frames: 40 },
       { type: AT.despawn },
    ],
-};
+});
 
-export const roundExplosion: IEnemyJson = {
+export const roundExplosion: IEnemyJson = createGameObject({
    name: "roundExplosion",
    diameter: 40,
    hp: 9999,
@@ -27,4 +27,4 @@ export const roundExplosion: IEnemyJson = {
       // { type: "wait", frames: 75 },
       { type: AT.despawn },
    ],
-};
+});

--- a/src/gameData/game2/enemies/boss.ts
+++ b/src/gameData/game2/enemies/boss.ts
@@ -3,6 +3,7 @@ import type { TAction } from "@/App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
+   createGameObject,
    forever,
    parallelAll,
    repeat,
@@ -77,7 +78,7 @@ const movePattern: TAction[] = [
    { type: AT.moveToAbsolute, frames: 60 * 7.5, moveTo: { x: col[5] }}
 ];
 
-export const boss: IEnemyJson = {
+export const boss: IEnemyJson = createGameObject({
    name: "boss",
    hp: 100_000, // immortal.
    diameter: 40,
@@ -90,4 +91,4 @@ export const boss: IEnemyJson = {
          shootingPattern
       )
    ]
-};
+});

--- a/src/gameData/game2/enemies/bossCorpse.ts
+++ b/src/gameData/game2/enemies/bossCorpse.ts
@@ -3,6 +3,7 @@ import type { TAction } from "@/App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
+   createGameObject,
    parallelAll,
    spawn,
    wait
@@ -28,7 +29,7 @@ const explodeInAllDirections = (radius: number, _wait: number,): TAction[] => {
    ];
 };
 
-export const bossCorpse: IEnemyJson = {
+export const bossCorpse: IEnemyJson = createGameObject({
    name: "bossCorpse",
    diameter: 18,
    hp: 9999,
@@ -43,4 +44,4 @@ export const bossCorpse: IEnemyJson = {
       { type: AT.wait, frames: 60 * 3 },
       { type: AT.finishLevel }
    ],
-};
+});

--- a/src/gameData/game2/enemies/dot.ts
+++ b/src/gameData/game2/enemies/dot.ts
@@ -1,11 +1,12 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
 import {
+   createGameObject,
    spawn,
 } from "@/gameData/utils";
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const dot: IEnemyJson = {
+export const dot: IEnemyJson = createGameObject({
    name: "dot",
    hp: 20,
    diameter: 20,
@@ -13,4 +14,4 @@ export const dot: IEnemyJson = {
    actions: [
       { type: AT.gfxSetShape, shape: "stage2/circle.png" },
    ]
-};
+});

--- a/src/gameData/game2/enemies/nonShootingAimer.ts
+++ b/src/gameData/game2/enemies/nonShootingAimer.ts
@@ -1,9 +1,11 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
-import { forever, parallelAll, repeat, setSpeed, spawn, wait } from "@/gameData/utils";
+import {
+   createGameObject, forever, parallelAll, repeat, setSpeed, spawn, wait
+} from "@/gameData/utils";
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const nonShootingAimer: IEnemyJson = {
+export const nonShootingAimer: IEnemyJson = createGameObject({
    name: "nonShootingAimer",
    hp: 1,
    diameter: 22,
@@ -21,4 +23,4 @@ export const nonShootingAimer: IEnemyJson = {
          )
       )
    ]
-};
+});

--- a/src/gameData/game2/enemies/spinningDots.ts
+++ b/src/gameData/game2/enemies/spinningDots.ts
@@ -3,6 +3,7 @@ import type { TAction } from "@/App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
+   createGameObject,
    forever,
    fork,
    spawn,
@@ -17,7 +18,7 @@ const rotate = ({ x, y }: { x?: number, y?: number }): TAction => ({
    point: { x, y }
 });
 
-export const spinningDots: IEnemyJson = {
+export const spinningDots: IEnemyJson = createGameObject({
    name: "spinningDots",
    hp: 9999,
    diameter: 5,
@@ -81,4 +82,4 @@ export const spinningDots: IEnemyJson = {
       }),
       { type: AT.despawn }
    ]
-};
+});

--- a/src/gameData/game2/enemies/traceDot.ts
+++ b/src/gameData/game2/enemies/traceDot.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
-import { wait } from "@/gameData/utils";
+import { createGameObject, wait } from "@/gameData/utils";
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const traceDot: IEnemyJson = {
+export const traceDot: IEnemyJson = createGameObject({
    name: "traceDot",
    hp: 9999,
    diameter: 5,
@@ -11,4 +11,4 @@ export const traceDot: IEnemyJson = {
       wait(3 * 60),
       { type: AT.despawn }
    ]
-};
+});

--- a/src/gameData/game2/parallax/parallax.ts
+++ b/src/gameData/game2/parallax/parallax.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
-import { forever, spawn, wait } from "@/gameData/utils";
+import { createGameObject, forever, spawn, wait } from "@/gameData/utils";
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const parallax: IEnemyJson = {
+export const parallax: IEnemyJson = createGameObject({
    name: "parallax",
    diameter: 240,
    hp: 9999,
@@ -16,9 +16,9 @@ export const parallax: IEnemyJson = {
       spawn("layer2"),
       spawn("layer3"),
    ],
-};
+});
 
-export const layer1: IEnemyJson = {
+export const layer1: IEnemyJson = createGameObject({
    name: "layer1",
    diameter: 240,
    hp: 9999,
@@ -31,9 +31,9 @@ export const layer1: IEnemyJson = {
          { type: AT.gfxScrollBg, x: 0.3 }
       )
    ],
-};
+});
 
-export const layer2: IEnemyJson = {
+export const layer2: IEnemyJson = createGameObject({
    name: "layer2",
    diameter: 240,
    hp: 9999,
@@ -46,9 +46,9 @@ export const layer2: IEnemyJson = {
          { type: AT.gfxScrollBg, x: 1 }
       )
    ],
-};
+});
 
-export const layer3: IEnemyJson = {
+export const layer3: IEnemyJson = createGameObject({
    name: "layer3",
    diameter: 240,
    hp: 9999,
@@ -61,4 +61,4 @@ export const layer3: IEnemyJson = {
          { type: AT.gfxScrollBg, x: 1.5 }
       )
    ],
-};
+});

--- a/src/gameData/game2/player/player.ts
+++ b/src/gameData/game2/player/player.ts
@@ -2,7 +2,7 @@ import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "../../../App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
-import { forever, fork, wait } from "../../utils";
+import { createGameObject, forever, fork, wait } from "../../utils";
 
 type TCreateShotArgs = { moveDeltaX: number, moveDeltaY: number };
 
@@ -22,7 +22,7 @@ const trippleShot: TAction[] = [
    wait(8),
 ];
 
-export const player: IEnemyJson = {
+export const player: IEnemyJson = createGameObject({
    name: "player",
    diameter: 20,
    hp: 1,
@@ -52,4 +52,4 @@ export const player: IEnemyJson = {
          ...trippleShot,
       )),
    ]
-};
+});

--- a/src/gameData/game2/player/playerShot.ts
+++ b/src/gameData/game2/player/playerShot.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { spawn } from "../../utils";
+import { createGameObject, spawn } from "../../utils";
 
-export const playerShot: IEnemyJson = {
+export const playerShot: IEnemyJson = createGameObject({
    name: "playerShot",
    hp: 1,
    diameter: 5,
@@ -16,4 +16,4 @@ export const playerShot: IEnemyJson = {
       { type: AT.gfxSetShape, shape: "circle" },
       { type: AT.gfxSetColor, color: "aqua" },
    ],
-};
+});

--- a/src/gameData/game2/shot.ts
+++ b/src/gameData/game2/shot.ts
@@ -1,8 +1,9 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+import { createGameObject } from "../utils";
 
-export const shot: IEnemyJson = {
+export const shot: IEnemyJson = createGameObject({
    name: "shot",
    hp: 9999,
    diameter: 5,
@@ -11,4 +12,4 @@ export const shot: IEnemyJson = {
       { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: AT.gfxSetShape, shape: "circle" }
    ]
-};
+});

--- a/src/gameData/game2/spawner.ts
+++ b/src/gameData/game2/spawner.ts
@@ -1,10 +1,10 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { fork, spawn, wait } from "../utils";
+import { createGameObject, fork, spawn, wait } from "../utils";
 import { col, row } from "./common";
 
-export const spawner: IEnemyJson = {
+export const spawner: IEnemyJson = createGameObject({
    name: "spawner",
    diameter: 20,
    hp: 9999,
@@ -20,4 +20,4 @@ export const spawner: IEnemyJson = {
       spawn("player", { x: col[1], y: row[5] }),
       spawn("stage"),
    ],
-};
+});

--- a/src/gameData/game2/stage.ts
+++ b/src/gameData/game2/stage.ts
@@ -1,6 +1,7 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import {
+   createGameObject,
    spawn,
    wait
 } from "../utils";
@@ -8,7 +9,7 @@ import { col, row } from "./common";
 import { aimersWave } from "./waves/aimers";
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 
-export const stage: IEnemyJson = {
+export const stage: IEnemyJson = createGameObject({
    name: "stage",
    diameter: 20,
    hp: 9999,
@@ -41,4 +42,4 @@ export const stage: IEnemyJson = {
       wait(60 * 6),
       spawn("boss", { x: col[12], y: row[5] }),
    ]
-};
+});

--- a/src/gameData/game3/effects/explosions.ts
+++ b/src/gameData/game3/effects/explosions.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { wait } from "../../utils";
+import { createGameObject, wait } from "../../utils";
 
-export const explosion: IEnemyJson = {
+export const explosion: IEnemyJson = createGameObject({
    name: "explosion",
    diameter: 18,
    hp: 9999,
@@ -14,9 +14,9 @@ export const explosion: IEnemyJson = {
       // { type: "wait", frames: 40 },
       { type: AT.despawn },
    ],
-};
+});
 
-export const roundExplosion: IEnemyJson = {
+export const roundExplosion: IEnemyJson = createGameObject({
    name: "roundExplosion",
    diameter: 40,
    hp: 9999,
@@ -27,4 +27,4 @@ export const roundExplosion: IEnemyJson = {
       // { type: "wait", frames: 75 },
       { type: AT.despawn },
    ],
-};
+});

--- a/src/gameData/game3/kamikaze/kamikazeCorpse.ts
+++ b/src/gameData/game3/kamikaze/kamikazeCorpse.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { wait } from "../../utils";
+import { createGameObject, wait } from "../../utils";
 
-export const kamikaze: IEnemyJson = {
+export const kamikaze: IEnemyJson = createGameObject({
    name: "kamikaze",
    diameter: 20,
    hp: 1,
@@ -14,9 +14,9 @@ export const kamikaze: IEnemyJson = {
       wait(90),
       // { type: "die" },
    ],
-};
+});
 
-export const kamikazeCorpse: IEnemyJson = {
+export const kamikazeCorpse: IEnemyJson = createGameObject({
    name: "kamikazeCorpse",
    diameter: 20,
    hp: 1,
@@ -34,4 +34,4 @@ export const kamikazeCorpse: IEnemyJson = {
       { type: AT.shootDirection, x: 0, y: -1 },
       { type: AT.despawn },
    ],
-};
+});

--- a/src/gameData/game3/kamikaze/sinus.ts
+++ b/src/gameData/game3/kamikaze/sinus.ts
@@ -2,7 +2,7 @@ import type { TAction, TMove } from "../../../App/services/Enemies/actions/actio
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
-import { Do, attr, parallelAll, twice, wait } from "../../utils";
+import { Do, attr, createGameObject, parallelAll, twice, wait } from "../../utils";
 
 const moveLeft: TMove = {
    type: AT.move,
@@ -43,7 +43,7 @@ const rotateRightAndShoot = parallelAll(
    shootWhileRotation
 );
 
-export const sinus: IEnemyJson = {
+export const sinus: IEnemyJson = createGameObject({
    name: "sinus",
    hp: 1,
    diameter: 24,
@@ -62,4 +62,4 @@ export const sinus: IEnemyJson = {
          moveLeft,
       )
    ],
-};
+});

--- a/src/gameData/game3/pacifistStage.ts
+++ b/src/gameData/game3/pacifistStage.ts
@@ -2,7 +2,7 @@ import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 import type { TSpawn } from "../../App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT} from "../../App/services/Enemies/actions/actionTypes";
-import { Do, repeat, wait } from "../utils";
+import { Do, createGameObject, repeat, wait } from "../utils";
 
 const sinusLeft: TSpawn = {
    type: AT.spawn, enemy: "sinus",
@@ -24,7 +24,7 @@ const sinuses = repeat(5, [
    Do(sinusRight, wait(70)),
 ]);
 
-export const pacifistStage: IEnemyJson = {
+export const pacifistStage: IEnemyJson = createGameObject({
    name: "pacifistStage",
    diameter: 20,
    hp: 9999,
@@ -34,4 +34,4 @@ export const pacifistStage: IEnemyJson = {
       wait(120),
       sinuses,
    ],
-};
+});

--- a/src/gameData/game3/player/player.ts
+++ b/src/gameData/game3/player/player.ts
@@ -2,7 +2,7 @@ import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 import type { TAction } from "../../../App/services/Enemies/actions/actionTypes";
 
 import { ActionType as AT } from "../../../App/services/Enemies/actions/actionTypes";
-import { forever, fork, wait } from "../../utils";
+import { createGameObject, forever, fork, wait } from "../../utils";
 
 type TCreateShotArgs = { moveDeltaX: number, moveDeltaY: number };
 
@@ -33,7 +33,7 @@ const laser: TAction[] = [
    wait(3),
 ];
 
-export const player: IEnemyJson = {
+export const player: IEnemyJson = createGameObject({
    name: "player",
    diameter: 20,
    hp: 1,
@@ -66,4 +66,4 @@ export const player: IEnemyJson = {
          ...laser,
       )),
    ]
-};
+});

--- a/src/gameData/game3/player/playerLaser.ts
+++ b/src/gameData/game3/player/playerLaser.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { forever, parallelRace, spawn, wait } from "../../utils";
+import { createGameObject, forever, parallelRace, spawn, wait } from "../../utils";
 
-export const playerLaser: IEnemyJson = {
+export const playerLaser: IEnemyJson = createGameObject({
    name: "playerLaser",
    hp: 1,
    diameter: 5,
@@ -26,4 +26,4 @@ export const playerLaser: IEnemyJson = {
          ]
       ),
    ]
-};
+});

--- a/src/gameData/game3/player/playerShot.ts
+++ b/src/gameData/game3/player/playerShot.ts
@@ -1,9 +1,9 @@
 import type { IEnemyJson } from "../../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
-import { spawn } from "../../utils";
+import { createGameObject, spawn } from "../../utils";
 
-export const playerShot: IEnemyJson = {
+export const playerShot: IEnemyJson = createGameObject({
    name: "playerShot",
    hp: 1,
    diameter: 5,
@@ -16,4 +16,4 @@ export const playerShot: IEnemyJson = {
       { type: AT.gfxSetShape, shape: "circle" },
       { type: AT.gfxSetColor, color: "aqua" },
    ],
-};
+});

--- a/src/gameData/game3/shot.ts
+++ b/src/gameData/game3/shot.ts
@@ -1,8 +1,9 @@
 import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
+import { createGameObject } from "../utils";
 
-export const shot: IEnemyJson = {
+export const shot: IEnemyJson = createGameObject({
    name: "shot",
    hp: 9999,
    diameter: 5,
@@ -11,4 +12,4 @@ export const shot: IEnemyJson = {
       { type: AT.setAttribute, attribute: "points", value: 0 },
       { type: AT.gfxSetShape, shape: "circle" }
    ]
-};
+});

--- a/src/gameData/game3/spawner.ts
+++ b/src/gameData/game3/spawner.ts
@@ -2,12 +2,13 @@ import type { IEnemyJson } from "../../gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "@/App/services/Enemies/actions/actionTypes";
 import {
+   createGameObject,
    // fork,
    spawn,
    // wait
 } from "../utils";
 
-export const spawner: IEnemyJson = {
+export const spawner: IEnemyJson = createGameObject({
    name: "spawner",
    diameter: 20,
    hp: 9999,
@@ -22,4 +23,4 @@ export const spawner: IEnemyJson = {
       spawn("player", { x: 178.5, y: 220 }),
       spawn("pacifistStage")
    ]
-};
+});

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -34,16 +34,31 @@ export function createGameObject(params: TCreateGameObjectParams): IEnemyJson {
       hp: params.hp,
       diameter: params.diameter,
       actions: [
+         // Set some default attributes.
+         { type: AT.setAttribute, attribute: "points", value: 10 },
+         { type: AT.setAttribute, attribute: "pointsOnDeath", value: 0 },
+         { type: AT.setAttribute, attribute: "collisionType", value: "enemy" },
+         { type: AT.setAttribute, attribute: "boundToWindow", value: false },
+         // Setup despawning when GameObject moves out of the screen.
+         {
+            type: AT.fork,
+            actions: [
+               { type: AT.waitTilInsideScreen },
+               { type: AT.waitTilOutsideScreen },
+               { type: AT.despawn }
+            ]
+         },
+         // Die when hp is 0. TODO: Actually it should be LTE to 0.
          fork(
             /**
              * TODO: since hp always exists on atributes I should prolly add it to type
              * so I get auto-completion
              */
-            // Die when hp is 0. TODO: Actually it should be LTE to 0.
             { type: AT.waitUntilAttrIs, attr: "hp", is: 0 },
             ...(params.onDeathAction ? [params.onDeathAction] : []),
             { type: AT.despawn },
          ),
+         // "Normal" actions
          ...params.actions
       ]
    };

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -2,21 +2,67 @@ import type {
    TAction, TAttrIs, TDo, TFork, TMoveToAbsolute, TNumber, TRepeat, TSetShotSpeed, TSetSpeed,
    TSpawn, TWait, TparallelAll, TparallelRace
 } from "../App/services/Enemies/actions/actionTypes";
+import type { IEnemyJson } from "@/gameTypes/IEnemyJson";
 
 import { ActionType as AT } from "../App/services/Enemies/actions/actionTypes";
+
+type TCreateGameObjectParams = {
+   name: string;
+   hp: number;
+   diameter: number;
+   actions: TAction[];
+   /**
+   * One action that is executed immediately when an enemy reaches 0 hp.
+   * MUST take at most 1 frame to execute.
+   * The reason for this is that the enemy has died and is
+   * being removed from the system. If you need to do more than 1 action then you may spawn a
+   * new GameObject and have those actions in that GameObject, I call this concept
+   * "spawning a corpse".
+   */
+   onDeathAction?: TAction | undefined;
+}
+/**
+ * A function I made as a middle layer to make so I would need to make fewer changes to gameObjects
+ * when adding the functionality for a player to have several lives.
+ * What I need is to remove the onDeathActions internally in the code and manage that manually
+ * with actions (and attriubutes).
+ * TODO: Maybe this should be removed when it is no longer needed??
+ */
+export function createGameObject(params: TCreateGameObjectParams): IEnemyJson {
+   return {
+      name: params.name,
+      hp: params.hp,
+      diameter: params.diameter,
+      actions: [
+         fork(
+            /**
+             * TODO: since hp always exists on atributes I should prolly add it to type
+             * so I get auto-completion
+             */
+            // Die when hp is 0. TODO: Actually it should be LTE to 0.
+            { type: AT.waitUntilAttrIs, attr: "hp", is: 0 },
+            ...(params.onDeathAction ? [params.onDeathAction] : []),
+            { type: AT.despawn },
+         ),
+         ...params.actions
+      ]
+   };
+}
 
 type TAttrParams = {
    is: TAttrIs["is"];
    yes?: TAttrIs["yes"];
    no?: TAttrIs["no"];
 };
-export const attr = (attrName: TAttrIs["attrName"], { is, yes, no }: TAttrParams): TAttrIs => ({
-   type: AT.attrIs,
-   attrName,
-   is,
-   yes,
-   no
-});
+export function attr(attrName: TAttrIs["attrName"], { is, yes, no }: TAttrParams): TAttrIs {
+   return {
+      type: AT.attrIs,
+      attrName,
+      is,
+      yes,
+      no
+   };
+}
 
 // first caps because `do` is a reserved word in js.
 export const Do = (...actions: TAction[]): TDo => ({
@@ -30,10 +76,12 @@ export const forever = (...actions: TAction[]): TRepeat => ({
    actions
 });
 
-export const fork = (...actions: TAction[]): TFork => ({
-   type: AT.fork,
-   actions
-});
+export function fork(...actions: TAction[]): TFork {
+   return {
+      type: AT.fork,
+      actions
+   };
+}
 
 type TMoveToAbsParams = { x?: number, y?: number, frames: number};
 export const moveToAbsolute = ({ x, y, frames }: TMoveToAbsParams): TMoveToAbsolute => ({
@@ -47,10 +95,12 @@ export const parallelAll = (...actions: (TAction|TAction[])[]): TparallelAll => 
    actionsLists: actions.map(acns => Array.isArray(acns) ? acns : [acns])
 });
 
-export const parallelRace = (...actions: (TAction|TAction[])[]): TparallelRace => ({
-   type: AT.parallelRace,
-   actionsLists: actions.map(acn => Array.isArray(acn) ? acn : [acn])
-});
+export function parallelRace(...actions: (TAction|TAction[])[]): TparallelRace {
+   return {
+      type: AT.parallelRace,
+      actionsLists: actions.map(acn => Array.isArray(acn) ? acn : [acn])
+   };
+}
 
 export const repeat = (times: TNumber, actions: TAction[]): TRepeat => ({
    type: AT.repeat,

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -31,7 +31,6 @@ type TCreateGameObjectParams = {
 export function createGameObject(params: TCreateGameObjectParams): IEnemyJson {
    return {
       name: params.name,
-      hp: params.hp,
       diameter: params.diameter,
       actions: [
          // Set some default attributes.
@@ -39,12 +38,14 @@ export function createGameObject(params: TCreateGameObjectParams): IEnemyJson {
          { type: AT.setAttribute, attribute: "pointsOnDeath", value: 0 },
          { type: AT.setAttribute, attribute: "collisionType", value: "enemy" },
          { type: AT.setAttribute, attribute: "boundToWindow", value: false },
+         { type: AT.setAttribute, attribute: "hp", value: params.hp },
+         { type: AT.setAttribute, attribute: "maxHp", value: params.hp },
          // Setup despawning when GameObject moves out of the screen.
          {
             type: AT.fork,
             actions: [
-               { type: AT.waitTilInsideScreen },
-               { type: AT.waitTilOutsideScreen },
+               { type: AT.waitTilInsideScreen }, // TODO: This should take a margin argument.
+               { type: AT.waitTilOutsideScreen }, // TODO: This should take a margin argument.
                { type: AT.despawn }
             ]
          },

--- a/src/gameTypes/IEnemyJson.ts
+++ b/src/gameTypes/IEnemyJson.ts
@@ -7,7 +7,6 @@ import type { TAction } from "../App/services/Enemies/actions/actionTypes";
  */
 export type IEnemyJson = {
   name: string;
-  hp: number; // actually maxHp
   diameter: number;
   actions: TAction[];
 }

--- a/src/gameTypes/IEnemyJson.ts
+++ b/src/gameTypes/IEnemyJson.ts
@@ -10,11 +10,4 @@ export type IEnemyJson = {
   hp: number; // actually maxHp
   diameter: number;
   actions: TAction[];
-  /**
-   * One action that is executed immediately when an enemy dies.
-   * MUST take at most 1 frame to execute.
-   * The reason for this is that the enemy has died and is
-   * being removed from the system, 
-   */
-  onDeathAction?: TAction;
 }


### PR DESCRIPTION
Previously it was hard-codd (internally in the engine) that the game would end when the player was hit.

This was not very dynamic, so I removed the hard-coded stuff so that the player can have any amount of hp.

I created a `createGameObject` method for level developer to use to get some very common behaviour (since more stuff in manually managed) which you dont need to use, but will most likely use since it included stuff such as despawning when enemies go outside of the screen etc.

What is going on in the code is that more and more things are managed manually via actions and there is less and less hard-coded stuff. The code will continue to go in this direction.

- Added a `log` action so you can log in actions when creating GameObjects.
- change name of event from player_died to gameOver
- I removed onDeathAction from IEnemyJSON. I removed internal code that would trigger killing an enemy. despawning and enemy and running oDeathAction is now done fully in actions to make it dynamic. I have a util function to help with that called createGameObject.
- bullets that did collide with playernow lose hp (they didnt previously because player only had 1 hp so game ended anyway)
- enemies bullets explode when hitting player.
- moved setting default attributes and despawn when move out of screen behaviour out of Enemies.ts and into utils.createGameObject
- moved setting hp and maxHp from Enemies.tx into utils.createGameObject
- added a comment