### PR TITLE
Remove hardcoding of player directional controls

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -122,6 +122,12 @@ module.exports = {
     "@typescript-eslint/no-duplicate-type-constituents": "error",
     "@typescript-eslint/prefer-nullish-coalescing": "error",
     "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "@typescript-eslint/no-import-type-side-effects": "error",
+    "@typescript-eslint/no-loop-func": "error",
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-unused-expressions": ["error", { allowShortCircuit: true  }],
+    "@typescript-eslint/no-use-before-define": "error",
+    "@typescript-eslint/return-await": "error",
 
     /************
      * Disables *

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -121,6 +121,7 @@ module.exports = {
     }],
     "@typescript-eslint/no-duplicate-type-constituents": "error",
     "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
 
     /************
      * Disables *

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -134,7 +134,7 @@ module.exports = {
     "@typescript-eslint/no-meaningless-void-operator": "error",
     "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
     // "@typescript-eslint/no-non-null-assertion": "error", // currently too harsh.
-    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+    // "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
     // "@typescript-eslint/no-unnecessary-condition": "error", // too harsh for someArray[i].
     "@typescript-eslint/prefer-includes": "error",
     "@typescript-eslint/prefer-reduce-type-parameter": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -128,6 +128,18 @@ module.exports = {
     "@typescript-eslint/no-unused-expressions": ["error", { allowShortCircuit: true  }],
     "@typescript-eslint/no-use-before-define": "error",
     "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/no-confusing-void-expression": "error",
+    // "@typescript-eslint/no-dynamic-delete": "error",// sometimes Map is faster than object delete
+    "@typescript-eslint/no-invalid-void-type": "error",
+    "@typescript-eslint/no-meaningless-void-operator": "error",
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+    // "@typescript-eslint/no-non-null-assertion": "error", // currently too harsh.
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+    // "@typescript-eslint/no-unnecessary-condition": "error", // too harsh for someArray[i].
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-return-this-type": "error",
+    "@typescript-eslint/no-throw-literal": "error",
 
     /************
      * Disables *

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -326,3 +326,6 @@ buttons though.
   (a GraphicsObject).
 
 * Margin on WaitUntilOutsideScreen should probably be the diameter by default.
+
+* There is a bug when you press UP + DOWN + RIGHT that you move faster then only RIGHT,
+  this is because it does upRight + downRight at the same time.

--- a/docs/whatImCurrentlyDoing.md
+++ b/docs/whatImCurrentlyDoing.md
@@ -6,11 +6,3 @@ it easier to make levels, debug texts, debug buttons and tools etc.
   * the attribute getter itself should be able to take an attribute getter!!!
 
 * Maybe I should do powerups next, or bomb? or maybe update controls to support more buttons.
-
-- Remove these actions, and replace them with a TWaitForInput = { type, inputs: [] }.
-It can wait for several inputs. Why? Because you might want special code for diagonal movement.
-  - TMoveAccordingToInput
-  - TWaitInputShoot
-  - TWaitInputLaser
-- I need to add `notPressed` to `TWaitForInput`. This is to make it possible to handle directional
-  input differently I one does not want diagonal movement to be straight up UP added with RIGHT.

--- a/docs/whatImCurrentlyDoing.md
+++ b/docs/whatImCurrentlyDoing.md
@@ -6,3 +6,11 @@ it easier to make levels, debug texts, debug buttons and tools etc.
   * the attribute getter itself should be able to take an attribute getter!!!
 
 * Maybe I should do powerups next, or bomb? or maybe update controls to support more buttons.
+
+- Remove these actions, and replace them with a TWaitForInput = { type, inputs: [] }.
+It can wait for several inputs. Why? Because you might want special code for diagonal movement.
+  - TMoveAccordingToInput
+  - TWaitInputShoot
+  - TWaitInputLaser
+- I need to add `notPressed` to `TWaitForInput`. This is to make it possible to handle directional
+  input differently I one does not want diagonal movement to be straight up UP added with RIGHT.

--- a/src/App/services/Collisions/Collisions.ts
+++ b/src/App/services/Collisions/Collisions.ts
@@ -103,6 +103,8 @@ export class Collisions implements IService {
             case "playerBullet":
                playerBullets.push(enemy);
                break;
+            default:
+               // NOOP
          }
       });
 

--- a/src/App/services/Enemies/ActionExecutor/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/ActionExecutor/EnemyActionExecutor.ts
@@ -14,6 +14,25 @@ import { GeneratorUtils } from "../../../../utils/GeneratorUtils";
 import { resolutionHeight, resolutionWidth } from "../../../../consts";
 import { ifAttr } from "./if";
 
+const rotateAroundPoint = function*(
+   currAction: TRotateAroundAbsolutePoint | TRotateAroundRelativePoint,
+   pointToPosVector: Vector,
+   actionHandler: TActionHandler
+): Generator<void, void, void> {
+   const stepDegrees = currAction.degrees / currAction.frames;
+   for(let passedFrames=1; passedFrames<=currAction.frames; passedFrames++) {
+      const prevDegrees = stepDegrees * (passedFrames-1);
+      const currDegrees = stepDegrees * passedFrames;
+
+      const prevRotated = pointToPosVector.rotateClockwise(Angle.fromDegrees(prevDegrees));
+      const currRotated = pointToPosVector.rotateClockwise(Angle.fromDegrees(currDegrees));
+
+      const delta = Vector.fromTo(prevRotated, currRotated);
+      actionHandler({ type: AT.moveDelta, x: delta.x, y: delta.y });
+      yield;
+   }
+};
+
 type TActionHandler = (action: TAction) => void;
 
 type TEnemyActionExecutorArgs = {
@@ -332,22 +351,3 @@ export class EnemyActionExecutor {
       }
    }
 }
-
-const rotateAroundPoint = function*(
-   currAction: TRotateAroundAbsolutePoint | TRotateAroundRelativePoint,
-   pointToPosVector: Vector,
-   actionHandler: TActionHandler
-): Generator<void, void, void> {
-   const stepDegrees = currAction.degrees / currAction.frames;
-   for(let passedFrames=1; passedFrames<=currAction.frames; passedFrames++) {
-      const prevDegrees = stepDegrees * (passedFrames-1);
-      const currDegrees = stepDegrees * passedFrames;
-
-      const prevRotated = pointToPosVector.rotateClockwise(Angle.fromDegrees(prevDegrees));
-      const currRotated = pointToPosVector.rotateClockwise(Angle.fromDegrees(currDegrees));
-
-      const delta = Vector.fromTo(prevRotated, currRotated);
-      actionHandler({ type: AT.moveDelta, x: delta.x, y: delta.y });
-      yield;
-   }
-};

--- a/src/App/services/Enemies/ActionExecutor/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/ActionExecutor/EnemyActionExecutor.ts
@@ -1,5 +1,3 @@
-// TODO: remove eslint-disable max-lines
-/* eslint-disable max-lines */
 import type {
    TAction, TInputButton, TNumber, TRotateAroundAbsolutePoint, TRotateAroundRelativePoint, TString
 } from "../actions/actionTypes";
@@ -171,18 +169,6 @@ export class EnemyActionExecutor {
                   !notPressed.some(isButtonPressed)
                )) { yield; }
 
-               break;
-            }
-
-            case AT.waitInputShoot: {
-               const shootPressed = () => this.shootPressed() && !this.laserPressed();
-               while(!shootPressed()) { yield; }
-               break;
-            }
-
-            case AT.waitInputLaser: {
-               const laserPressed = () => this.laserPressed();
-               while(!laserPressed()) { yield; }
                break;
             }
 

--- a/src/App/services/Enemies/ActionExecutor/EnemyActionExecutor.ts
+++ b/src/App/services/Enemies/ActionExecutor/EnemyActionExecutor.ts
@@ -1,7 +1,7 @@
 // TODO: remove eslint-disable max-lines
 /* eslint-disable max-lines */
 import type {
-   TAction, TNumber, TRotateAroundAbsolutePoint, TRotateAroundRelativePoint, TString
+   TAction, TInputButton, TNumber, TRotateAroundAbsolutePoint, TRotateAroundRelativePoint, TString
 } from "../actions/actionTypes";
 import type { Vector as TVector } from "../../../../math/bezier";
 import type { IAttributes, TAttrValue } from "../../Attributes/IAttributes";
@@ -93,24 +93,10 @@ export class EnemyActionExecutor {
     */
 
    // Some utils for controls. I should probably refactor this somehow.
-   private _leftPressed = () => this.input.ButtonsPressed.left || this.gamepad.left;
-   private _rightPressed = () => this.input.ButtonsPressed.right || this.gamepad.right;
-   private _upPressed = () => this.input.ButtonsPressed.up || this.gamepad.up;
-   private _downPressed = () => this.input.ButtonsPressed.down || this.gamepad.down;
-
-   private leftPressed = () =>
-      this._leftPressed() && !this._upPressed() && !this._downPressed();
-   private rightPressed = () =>
-      this._rightPressed() && !this._upPressed() && !this._downPressed();
-   private upPressed = () =>
-      this._upPressed() && !this._leftPressed() && !this._rightPressed();
-   private downPressed = () =>
-      this._downPressed() && !this._leftPressed() && !this._rightPressed();
-
-   private upLeftPressed = () => this._upPressed() && this._leftPressed();
-   private upRightPressed = () => this._upPressed() && this._rightPressed();
-   private downLeftPressed = () => this._downPressed() && this._leftPressed();
-   private downRightPressed = () => this._downPressed() && this._rightPressed();
+   private leftPressed = () => this.input.ButtonsPressed.left || this.gamepad.left;
+   private rightPressed = () => this.input.ButtonsPressed.right || this.gamepad.right;
+   private upPressed = () => this.input.ButtonsPressed.up || this.gamepad.up;
+   private downPressed = () => this.input.ButtonsPressed.down || this.gamepad.down;
 
    private shootPressed = () => this.input.ButtonsPressed.shoot || this.gamepad.shoot;
    private laserPressed = () => this.input.ButtonsPressed.laser || this.gamepad.laser;
@@ -155,45 +141,35 @@ export class EnemyActionExecutor {
          const currAction = actions[currIndex];
          switch(currAction.type) {
             case AT.waitForInput: {
-               const button = currAction.inputs[0];
-               
-               switch(button) {
-                  case "left":
-                     while(!this.leftPressed()) { yield; }
-                     break;
-                  case "right":
-                     while(!this.rightPressed()) { yield; }
-                     break;
-                  case "up":
-                     while(!this.upPressed()) { yield; }
-                     break;
-                  case "down":
-                     while(!this.downPressed()) { yield; }
-                     break;
+               const pressed = currAction.pressed;
+               const notPressed = currAction.notPressed ?? [];
 
-                  case "upLeft":
-                     while(!this.upLeftPressed()) { yield; }
-                     break;
-                  case "upRight":
-                     while(!this.upRightPressed()) { yield; }
-                     break;
-                  case "downLeft":
-                     while(!this.downLeftPressed()) { yield; }
-                     break;
-                  case "downRight":
-                     while(!this.downRightPressed()) { yield; }
-                     break;
+               const isButtonPressed = (button: TInputButton): boolean => {
+                  switch(button) {
+                     case "left":
+                        return this.leftPressed();
+                     case "right":
+                        return this.rightPressed();
+                     case "up":
+                        return this.upPressed();
+                     case "down":
+                        return this.downPressed();
 
-                  case "shoot":
-                     while(!this.shootPressed()) { yield; }
-                     break;
-                  case "laser":
-                     while(!this.laserPressed()) { yield; }
-                     break;
-                  case "start":
-                     while(!this.startPressed()) { yield; }
-                     break;
-               }
+                     case "shoot":
+                        return this.shootPressed();
+                     case "laser":
+                        return this.laserPressed();
+                     case "start":
+                        return this.startPressed();
+                  }
+               };
+
+               while(!(
+                  // every button in pressed must be pressed.
+                  pressed.every(isButtonPressed) &&
+                  // if some button in notPressed is pressed then return false.
+                  !notPressed.some(isButtonPressed)
+               )) { yield; }
 
                break;
             }

--- a/src/App/services/Enemies/Enemies.ts
+++ b/src/App/services/Enemies/Enemies.ts
@@ -170,6 +170,8 @@ export class Enemies implements IService {
                }
             });
             break;
+         default:
+            // NOOP
       }
    };
 }

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -37,11 +37,6 @@ export enum ActionType {
    waitTilInsideScreen = "waitTilInsideScreen",
    fork = "fork",
    setMoveDirection = "setMoveDirection",
-
-   moveAccordingToInput = "moveAccordingToInput", // TODO: remove
-   waitInputShoot = "waitInputShoot", // TODO: remove
-   waitInputLaser = "waitInputLaser", // TODO: remove
-
    waitForInput = "waitForInput",
    finishLevel = "finishLevel",
    
@@ -202,14 +197,6 @@ export type TWaitUntilAttrIs = Readonly<{
 }>;
 
 /**
- * This action is a way to react to input/gamepad/controls, mainly made in order
- * to allow the Player to be an Enemy (i.e. GameObject)
- */
-// TODO: remove these. They are replaced by waitForInput
-export type TWaitInputShoot = Readonly<{ type: ActionType.waitInputShoot }>;
-export type TWaitInputLaser = Readonly<{ type: ActionType.waitInputLaser }>;
-
-/**
  * TODO: Move this type and makes use of it in Input.ts. It does not look right to have it here.
  */
 export type TInputButton =
@@ -269,8 +256,6 @@ export type TAction = Readonly<
    /**
     * Controls/input
     */
-   TWaitInputShoot | // TODO: remove
-   TWaitInputLaser | // TODO: remove
    TWaitForInput |
    /**
    * Spawning/Life cycle

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -214,15 +214,18 @@ export type TWaitInputLaser = Readonly<{ type: ActionType.waitInputLaser }>;
  */
 export type TInputButton =
    "up" | "down" | "left" | "right" |
-   "upLeft" | "upRight" | "downLeft" | "downRight" |
    "laser" | "shoot" | "start";
 /**
  * Waits until the user presses a button.
- * @param inputs The buttons to wait for.
+ * @param pressed The buttons to wait for until they are pressed.
+ * @param notPressed These buttons must not be pressed.
+ *    notPressed exists because it allows you to wait for a button to be released, or to
+ *    handle directional buttons specially.
  */
 export type TWaitForInput = Readonly<{
    type: ActionType.waitForInput,
-   inputs: [TInputButton] | [TInputButton, TInputButton],
+   pressed: TInputButton[],
+   notPressed?: TInputButton[]
 }>;
 
 // Signals that the level has been finished, so trigger this when end boss dies or something similar

--- a/src/App/services/Enemies/actions/actionTypes.ts
+++ b/src/App/services/Enemies/actions/actionTypes.ts
@@ -37,9 +37,12 @@ export enum ActionType {
    waitTilInsideScreen = "waitTilInsideScreen",
    fork = "fork",
    setMoveDirection = "setMoveDirection",
-   moveAccordingToInput = "moveAccordingToInput",
-   waitInputShoot = "waitInputShoot",
-   waitInputLaser = "waitInputLaser",
+
+   moveAccordingToInput = "moveAccordingToInput", // TODO: remove
+   waitInputShoot = "waitInputShoot", // TODO: remove
+   waitInputLaser = "waitInputLaser", // TODO: remove
+
+   waitForInput = "waitForInput",
    finishLevel = "finishLevel",
    
    /**
@@ -202,9 +205,25 @@ export type TWaitUntilAttrIs = Readonly<{
  * This action is a way to react to input/gamepad/controls, mainly made in order
  * to allow the Player to be an Enemy (i.e. GameObject)
  */
-export type TMoveAccordingToInput = Readonly<{ type: ActionType.moveAccordingToInput }>;
+// TODO: remove these. They are replaced by waitForInput
 export type TWaitInputShoot = Readonly<{ type: ActionType.waitInputShoot }>;
 export type TWaitInputLaser = Readonly<{ type: ActionType.waitInputLaser }>;
+
+/**
+ * TODO: Move this type and makes use of it in Input.ts. It does not look right to have it here.
+ */
+export type TInputButton =
+   "up" | "down" | "left" | "right" |
+   "upLeft" | "upRight" | "downLeft" | "downRight" |
+   "laser" | "shoot" | "start";
+/**
+ * Waits until the user presses a button.
+ * @param inputs The buttons to wait for.
+ */
+export type TWaitForInput = Readonly<{
+   type: ActionType.waitForInput,
+   inputs: [TInputButton] | [TInputButton, TInputButton],
+}>;
 
 // Signals that the level has been finished, so trigger this when end boss dies or something similar
 export type TFinishLevel = Readonly<{ type: ActionType.finishLevel }>;
@@ -247,9 +266,9 @@ export type TAction = Readonly<
    /**
     * Controls/input
     */
-   TMoveAccordingToInput |
-   TWaitInputShoot |
-   TWaitInputLaser |
+   TWaitInputShoot | // TODO: remove
+   TWaitInputLaser | // TODO: remove
+   TWaitForInput |
    /**
    * Spawning/Life cycle
    */

--- a/src/App/services/GamePad/GamePad.ts
+++ b/src/App/services/GamePad/GamePad.ts
@@ -47,7 +47,7 @@ export class GamePad implements IService {
          if(!gamepad) {
             return false;
          }
-         return !!gamepad.buttons?.[index]?.pressed;
+         return !!gamepad.buttons[index]?.pressed;
       })!;
    };
 }

--- a/src/App/services/Graphics/GraphicsElement.ts
+++ b/src/App/services/Graphics/GraphicsElement.ts
@@ -324,7 +324,7 @@ export class GraphicsElement implements IDestroyable {
 
       // x
       if(x !== undefined){
-         const withoutPx = this.element.style.backgroundPositionX.replace("px", "") ?? "";
+         const withoutPx = this.element.style.backgroundPositionX.replace("px", "");
          const currentScrollX = parseFloat(withoutPx) || 0; // TODO: error if NaN
          const nextScrollX = currentScrollX + x;
          // TODO: this should not be needed to happen every time, i.e. setting repeat-y.
@@ -334,7 +334,7 @@ export class GraphicsElement implements IDestroyable {
 
       // y
       if(y !== undefined){
-         const withoutPx = this.element.style.backgroundPositionY.replace("px", "") ?? "";
+         const withoutPx = this.element.style.backgroundPositionY.replace("px", "");
          const currentScrollY = parseFloat(withoutPx) || 0; // TODO: error if NaN
          const nextScrollY = currentScrollY + y;
          // TODO: this should not be needed to happen every time, i.e. setting repeat-y.

--- a/src/App/services/Highscore/Highscore.ts
+++ b/src/App/services/Highscore/Highscore.ts
@@ -73,7 +73,7 @@ export class Highscore implements IService {
 
             // If localStorage is an older version then skip it.
             const parsedfromLocalStorage = JSON.parse(fromLocalStorage) as unknown;
-            if(isObject(parsedfromLocalStorage) && parsedfromLocalStorage?.version === 2) {
+            if(isObject(parsedfromLocalStorage) && parsedfromLocalStorage.version === 2) {
                this.highscores = parsedfromLocalStorage as THighscores;
             }
          } else {

--- a/src/App/services/Input/Input.ts
+++ b/src/App/services/Input/Input.ts
@@ -29,6 +29,9 @@ export class Input implements IInput {
       up: false,
       down: false,
    };
+   /**
+    * onKeyUpCallback seems to be used by UI exclusively. 
+    */
    public onKeyUpCallback?: (key: TKey) => void;
    /**
     * Keep track of which frame it is "locally" in this object.
@@ -67,6 +70,7 @@ export class Input implements IInput {
    };
 
    public get ButtonsPressed(): ButtonsPressed {
+      //#region push to history
       const frame = this.frameCount;
       const buttonsPressed = { ...this.buttonsPressed };
       const wasPressed = Object.values(buttonsPressed).includes(true);
@@ -82,6 +86,7 @@ export class Input implements IInput {
          });
          this.history.inputs[frame] = buttonsPressed;
       }
+      //#endregion
       return this.buttonsPressed;
    }
 

--- a/src/App/services/Input/Input.ts
+++ b/src/App/services/Input/Input.ts
@@ -79,7 +79,7 @@ export class Input implements IInput {
             if(k === "laser" || k === "shoot" || k === "up" ||
                k === "down" || k === "left" || k === "right" ||
                k === "start") {
-               if(buttonsPressed[k] === false) {
+               if(!buttonsPressed[k]) {
                   delete buttonsPressed[k];
                }
             }

--- a/src/App/services/Input/Input.ts
+++ b/src/App/services/Input/Input.ts
@@ -79,7 +79,7 @@ export class Input implements IInput {
             if(k === "laser" || k === "shoot" || k === "up" ||
                k === "down" || k === "left" || k === "right" ||
                k === "start") {
-               if(!buttonsPressed[k]) {
+               if(buttonsPressed[k] === false) {
                   delete buttonsPressed[k];
                }
             }

--- a/src/App/services/Input/mocks/ReplayerInput.ts
+++ b/src/App/services/Input/mocks/ReplayerInput.ts
@@ -46,6 +46,8 @@ export class ReplayerInput implements IInput {
             case "frame_tick":
                this.frameCount = event.frameNr;
                break;
+            default:
+               // NOOP
          }
       });
    };

--- a/src/App/services/Points/Points.ts
+++ b/src/App/services/Points/Points.ts
@@ -40,6 +40,8 @@ export class Points implements IPoints {
             // unsub because we dont want to get in here again.
             this.app.events.unsubscribeToEvent(this.name);
             break;
+         default:
+            // NOOP
       }
    };
 

--- a/src/App/services/UI/Scenes/Highscore.ts
+++ b/src/App/services/UI/Scenes/Highscore.ts
@@ -58,11 +58,11 @@ export class Highscore implements IScene {
    // if rank is a number it intructs to highlight that rank in the top10 list.
    public render(props: unknown) {
       if(isObject(props)) {
-         if(isNumber(props?.rank)) {
+         if(isNumber(props.rank)) {
             this.rank = props.rank;
          }
-         if(isBoolean(props?.backButton)) {
-            this.backButton = props?.backButton;
+         if(isBoolean(props.backButton)) {
+            this.backButton = props.backButton;
          }
       }
       this.shadeElement = createShade();

--- a/src/App/services/UI/Scenes/components/molecules/Countdown.ts
+++ b/src/App/services/UI/Scenes/components/molecules/Countdown.ts
@@ -78,6 +78,8 @@ export class Countdown {
                   this.onDone();
                }
                break;
+            default:
+               // NOOP
          }
       };
    }

--- a/src/App/services/UI/Scenes/components/molecules/FlipCharacters.ts
+++ b/src/App/services/UI/Scenes/components/molecules/FlipCharacters.ts
@@ -79,6 +79,8 @@ export class FlipCharacters {
             case "start":
                this.onDone(this.getEnteredString());
                break;
+            default:
+               // NOOP
          }
       };
    }

--- a/src/App/services/UI/Scenes/components/molecules/FlipCharacters.ts
+++ b/src/App/services/UI/Scenes/components/molecules/FlipCharacters.ts
@@ -138,18 +138,18 @@ export class FlipCharacters {
    };
 
    private incrCaretIndex = () => {
-      if(this.caretIndex === undefined) {
-         return;
-      }
+      // if(this.caretIndex === undefined) {
+      //    return;
+      // }
       if(this.caretIndex < this.charIndices.length - 1) {
          this.setCaretIndex(this.caretIndex + 1);
       }
    };
 
    private decrCaretIndex = () => {
-      if(this.caretIndex === undefined) {
-         return;
-      }
+      // if(this.caretIndex === undefined) {
+      //    return;
+      // }
       if(this.caretIndex >= 1) {
          this.setCaretIndex(this.caretIndex - 1);
       }

--- a/src/App/services/UI/Scenes/components/molecules/Menu.ts
+++ b/src/App/services/UI/Scenes/components/molecules/Menu.ts
@@ -69,6 +69,8 @@ export class Menu {
                   this.menuItems[this.activeItemIndex].onClick();
                }
                break;
+            default:
+               // NOOP
          }
       };
    }

--- a/src/App/services/UI/UI.ts
+++ b/src/App/services/UI/UI.ts
@@ -108,6 +108,8 @@ export class UI implements IUI {
             this.SetActiveScene(this.gameOver);
             break;
          }
+         default:
+            // NOOP
       }
    };
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,10 +10,10 @@ export const resolutionHeight = 240; // confirmed correct!
 const frameRate = 60;
 export const millisPerFrame = 1000 / frameRate;
 
-export const playerSpeedPerFrame = [
-   // zero upgrades
-   2.35 // confirmed correct!
-]; 
+// const playerSpeedPerFrame = [
+//    // zero upgrades
+//    2.35 // confirmed correct!
+// ] as const;
 
 // export const framesBewteenPlayerShots = 8;
 // export const playerShotSpeed = 9;

--- a/src/drivers/BrowserDriver/RealBrowserDriver.ts
+++ b/src/drivers/BrowserDriver/RealBrowserDriver.ts
@@ -65,13 +65,13 @@ export class RealBrowserDriver implements IBrowserDriver {
    public FetchText = async (input: RequestInfo | URL): Promise<string> => {
       // eslint-disable-next-line no-undef
       const res = await window.fetch(input);
-      return await res.text();
+      return res.text();
    };
 
    public FetchBinary = async (input: RequestInfo | URL): Promise<Blob> => {
       // eslint-disable-next-line no-undef
       const res = await window.fetch(input);
-      return await res.blob();
+      return res.blob();
    };
 
    public SaveFile = async (_path: string, _data: string) => {

--- a/src/gameData/game1/player/player.ts
+++ b/src/gameData/game1/player/player.ts
@@ -37,7 +37,7 @@ export const player = createGameObject({
    diameter: 20,
    hp: 1,
    onDeathAction: { type: AT.finishLevel }, // TODO: finishLevel should maybe be called gameOver.
-   options: { despawnWhenOutsideScreen: false },
+   options: { despawnWhenOutsideScreen: false, defaultDirectionalControls: true },
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
@@ -54,10 +54,6 @@ export const player = createGameObject({
       { type: AT.gfxSetShape, shape: "none" },
       wait(1),
       { type: AT.gfxSetShape, shape: "diamondShield" },
-      fork(forever(
-         { type: AT.moveAccordingToInput },
-         { type: AT.waitNextFrame }
-      )),
       fork(forever(
          { type: AT.waitInputShoot },
          ...trippleShot,

--- a/src/gameData/game1/player/player.ts
+++ b/src/gameData/game1/player/player.ts
@@ -55,11 +55,11 @@ export const player = createGameObject({
       wait(1),
       { type: AT.gfxSetShape, shape: "diamondShield" },
       fork(forever(
-         { type: AT.waitInputShoot },
+         { type: AT.waitForInput, pressed: ["shoot"], notPressed: ["laser"] },
          ...trippleShot,
       )),
       fork(forever(
-         { type: AT.waitInputLaser },
+         { type: AT.waitForInput, pressed: ["laser"] },
          ...laser
       )),
    ]

--- a/src/gameData/game2/player/player.ts
+++ b/src/gameData/game2/player/player.ts
@@ -46,7 +46,7 @@ export const player: TGameObject = createGameObject({
       wait(1),
       { type: AT.gfxSetShape, shape: "stage2/player.png" },
       fork(forever(
-         { type: AT.waitInputShoot },
+         { type: AT.waitForInput, pressed: ["shoot"], notPressed: ["laser"] },
          ...trippleShot,
       )),
    ]

--- a/src/gameData/game2/player/player.ts
+++ b/src/gameData/game2/player/player.ts
@@ -27,6 +27,7 @@ export const player: TGameObject = createGameObject({
    diameter: 20,
    hp: 1,
    onDeathAction: { type: AT.finishLevel },
+   options: { despawnWhenOutsideScreen: false, defaultDirectionalControls: true },
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
@@ -44,10 +45,6 @@ export const player: TGameObject = createGameObject({
       { type: AT.setMoveDirection, degrees: 90 },
       wait(1),
       { type: AT.gfxSetShape, shape: "stage2/player.png" },
-      fork(forever(
-         { type: AT.moveAccordingToInput },
-         { type: AT.waitNextFrame }
-      )),
       fork(forever(
          { type: AT.waitInputShoot },
          ...trippleShot,

--- a/src/gameData/game3/player/player.ts
+++ b/src/gameData/game3/player/player.ts
@@ -56,11 +56,11 @@ export const player: TGameObject = createGameObject({
       wait(1),
       { type: AT.gfxSetShape, shape: "diamondShield" },
       fork(forever(
-         { type: AT.waitInputShoot },
+         { type: AT.waitForInput, pressed: ["shoot"], notPressed: ["laser"] },
          ...trippleShot,
       )),
       fork(forever(
-         { type: AT.waitInputLaser },
+         { type: AT.waitForInput, pressed: ["laser"] },
          ...laser,
       )),
    ]

--- a/src/gameData/game3/player/player.ts
+++ b/src/gameData/game3/player/player.ts
@@ -38,6 +38,7 @@ export const player: TGameObject = createGameObject({
    diameter: 20,
    hp: 1,
    onDeathAction: { type: AT.finishLevel },
+   options: { despawnWhenOutsideScreen: false, defaultDirectionalControls: true },
    actions: [
       //set points to 0, otherwise you get points when the player dies since default is 10 currently
       { type: AT.setAttribute, attribute: "points", value: 0 },
@@ -54,10 +55,6 @@ export const player: TGameObject = createGameObject({
       { type: AT.gfxSetShape, shape: "none" },
       wait(1),
       { type: AT.gfxSetShape, shape: "diamondShield" },
-      fork(forever(
-         { type: AT.moveAccordingToInput },
-         { type: AT.waitNextFrame }
-      )),
       fork(forever(
          { type: AT.waitInputShoot },
          ...trippleShot,

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -52,44 +52,48 @@ export function createGameObject(params: TCreateGameObjectParams): TGameObject {
    const defaultDirectionalControlsActions: TAction[] = defaultDirectionalControls ? [
       // cardinal
       fork(forever(
-         { type: AT.waitForInput, inputs: ["left"] },
+         // notPressed is set because I don't want this to trigger for diagonal movement.
+         { type: AT.waitForInput, pressed: ["left"], notPressed: ["up", "down"] },
          { type: AT.moveDelta, x: -2.35 },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: AT.waitForInput, inputs: ["right"] },
+         // notPressed is set because I don't want this to trigger for diagonal movement.
+         { type: AT.waitForInput, pressed: ["right"], notPressed: ["up", "down"] },
          { type: AT.moveDelta, x: 2.35 },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: AT.waitForInput, inputs: ["up"] },
+         // notPressed is set because I don't want this to trigger for diagonal movement.
+         { type: AT.waitForInput, pressed: ["up"], notPressed: ["left", "right"] },
          { type: AT.moveDelta, y: -2.35 },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: AT.waitForInput, inputs: ["down"] },
+         // notPressed is set because I don't want this to trigger for diagonal movement.
+         { type: AT.waitForInput, pressed: ["down"], notPressed: ["left", "right"] },
          { type: AT.moveDelta, y: 2.35 },
          { type: AT.waitNextFrame }
       )),
 
       // diagonal
       fork(forever(
-         { type: AT.waitForInput, inputs: ["upLeft"] },
+         { type: AT.waitForInput, pressed: ["up", "left"] },
          { type: AT.moveDelta, x: -2.35/Math.SQRT2, y: -2.35/Math.SQRT2 },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: AT.waitForInput, inputs: ["upRight"] },
+         { type: AT.waitForInput, pressed: ["up", "right"] },
          { type: AT.moveDelta, x: 2.35/Math.SQRT2, y: -2.35/Math.SQRT2 },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: AT.waitForInput, inputs: ["downLeft"] },
+         { type: AT.waitForInput, pressed: ["down", "left"] },
          { type: AT.moveDelta, x: -2.35/Math.SQRT2, y: 2.35/Math.SQRT2 },
          { type: AT.waitNextFrame }
       )),
       fork(forever(
-         { type: AT.waitForInput, inputs: ["downRight"] },
+         { type: AT.waitForInput, pressed: ["down", "right"] },
          { type: AT.moveDelta, x: 2.35/Math.SQRT2, y: 2.35/Math.SQRT2 },
          { type: AT.waitNextFrame }
       )),

--- a/src/gameData/utils.ts
+++ b/src/gameData/utils.ts
@@ -6,6 +6,100 @@ import type { TGameObject } from "@/gameTypes/TGameObject";
 
 import { ActionType as AT } from "../App/services/Enemies/actions/actionTypes";
 
+type TAttrParams = {
+   condition?: TAttrIf["condition"];
+   value: TAttrIf["value"];
+   yes?: TAttrIf["yes"];
+   no?: TAttrIf["no"];
+};
+export function attr(
+   attrName: TAttrIf["attrName"], { condition="equals", value, yes, no }: TAttrParams
+): TAttrIf {
+   return {
+      condition,
+      type: AT.attrIf,
+      attrName,
+      value: value,
+      yes,
+      no
+   };
+}
+
+// first caps because `do` is a reserved word in js.
+export const Do = (...actions: TAction[]): TDo => ({
+   type: AT.do,
+   acns: actions
+});
+
+export function forever(...actions: TAction[]): TRepeat {
+   return {
+      type: AT.repeat,
+      times: 100_000_000,
+      actions
+   };
+}
+
+export function fork(...actions: TAction[]): TFork {
+   return {
+      type: AT.fork,
+      actions
+   };
+}
+
+type TMoveToAbsParams = { x?: number, y?: number, frames: number};
+export const moveToAbsolute = ({ x, y, frames }: TMoveToAbsParams): TMoveToAbsolute => ({
+   type: AT.moveToAbsolute,
+   moveTo: { x, y },
+   frames
+});
+
+export const parallelAll = (...actions: (TAction|TAction[])[]): TparallelAll => ({
+   type: AT.parallelAll,
+   actionsLists: actions.map(acns => Array.isArray(acns) ? acns : [acns])
+});
+
+export function parallelRace(...actions: (TAction|TAction[])[]): TparallelRace {
+   return {
+      type: AT.parallelRace,
+      actionsLists: actions.map(acn => Array.isArray(acn) ? acn : [acn])
+   };
+}
+
+export const repeat = (times: TNumber, actions: TAction[]): TRepeat => ({
+   type: AT.repeat,
+   times,
+   actions
+});
+
+export const setSpeed = (pixelsPerFrame: number): TSetSpeed => ({
+   type: AT.setSpeed,
+   pixelsPerFrame
+});
+
+type TSpawnParams = {
+   x?: number;
+   y?: number;
+   actions?: (TAction)[]
+}
+export const spawn = (enemy: string, params?: TSpawnParams): TSpawn => ({
+   type: AT.spawn,
+   enemy,
+   x: params?.x,
+   y: params?.y,
+   actions: params?.actions
+});
+
+export const setShotSpeed = (pixelsPerFrame: number): TSetShotSpeed => ({
+   type: AT.setShotSpeed,
+   pixelsPerFrame
+});
+
+export const thrice = (...actions: TAction[]): TRepeat => repeat(3, actions);
+
+export const twice = (...actions: TAction[]): TRepeat => repeat(2, actions);
+
+export const wait = (frames: TNumber): TWait => ({ type: AT.wait, frames });
+
 type TCreateGameObjectParams = {
    name: string;
    hp: number; // TODO: | "invincible"
@@ -140,97 +234,3 @@ export function createGameObject(params: TCreateGameObjectParams): TGameObject {
       ]
    };
 }
-
-type TAttrParams = {
-   condition?: TAttrIf["condition"];
-   value: TAttrIf["value"];
-   yes?: TAttrIf["yes"];
-   no?: TAttrIf["no"];
-};
-export function attr(
-   attrName: TAttrIf["attrName"], { condition="equals", value, yes, no }: TAttrParams
-): TAttrIf {
-   return {
-      condition,
-      type: AT.attrIf,
-      attrName,
-      value: value,
-      yes,
-      no
-   };
-}
-
-// first caps because `do` is a reserved word in js.
-export const Do = (...actions: TAction[]): TDo => ({
-   type: AT.do,
-   acns: actions
-});
-
-export function forever(...actions: TAction[]): TRepeat {
-   return {
-      type: AT.repeat,
-      times: 100_000_000,
-      actions
-   };
-}
-
-export function fork(...actions: TAction[]): TFork {
-   return {
-      type: AT.fork,
-      actions
-   };
-}
-
-type TMoveToAbsParams = { x?: number, y?: number, frames: number};
-export const moveToAbsolute = ({ x, y, frames }: TMoveToAbsParams): TMoveToAbsolute => ({
-   type: AT.moveToAbsolute,
-   moveTo: { x, y },
-   frames
-});
-
-export const parallelAll = (...actions: (TAction|TAction[])[]): TparallelAll => ({
-   type: AT.parallelAll,
-   actionsLists: actions.map(acns => Array.isArray(acns) ? acns : [acns])
-});
-
-export function parallelRace(...actions: (TAction|TAction[])[]): TparallelRace {
-   return {
-      type: AT.parallelRace,
-      actionsLists: actions.map(acn => Array.isArray(acn) ? acn : [acn])
-   };
-}
-
-export const repeat = (times: TNumber, actions: TAction[]): TRepeat => ({
-   type: AT.repeat,
-   times,
-   actions
-});
-
-export const setSpeed = (pixelsPerFrame: number): TSetSpeed => ({
-   type: AT.setSpeed,
-   pixelsPerFrame
-});
-
-type TSpawnParams = {
-   x?: number;
-   y?: number;
-   actions?: (TAction)[]
-}
-export const spawn = (enemy: string, params?: TSpawnParams): TSpawn => ({
-   type: AT.spawn,
-   enemy,
-   x: params?.x,
-   y: params?.y,
-   actions: params?.actions
-});
-
-export const setShotSpeed = (pixelsPerFrame: number): TSetShotSpeed => ({
-   type: AT.setShotSpeed,
-   pixelsPerFrame
-});
-
-export const thrice = (...actions: TAction[]): TRepeat => repeat(3, actions);
-
-export const twice = (...actions: TAction[]): TRepeat => repeat(2, actions);
-
-export const wait = (frames: TNumber): TWait => ({ type: AT.wait, frames });

--- a/src/math/Vector.ts
+++ b/src/math/Vector.ts
@@ -122,7 +122,7 @@ export class Vector {
 
    // Mutation functions are suffixed with a "M"
 
-   public rotateClockwiseM(angle: Angle): Vector {
+   public rotateClockwiseM(angle: Angle): this {
       const x = this.x;
       const y = this.y;
       const radians = angle.radians;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,13 @@
     "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",
+    "verbatimModuleSyntax": true,
     "lib": [
       "ESNext",
       "DOM"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "node10",
+    // "moduleResolution": "bundler", // sems to be recommended by Vite.
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
- Player controls are not hard-coded any more.
- TWaitForInput can listen to any of the left, right, up, down, shoot, start, laser buttons now so you could add controls to anything really, like 2 player mode or whatever.
- tightened eslint a bit with some more rules.